### PR TITLE
WIP: start trying to fix on julia nightly

### DIFF
--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -99,7 +99,7 @@ end
 function f_recv(c_ctx, c_msg, sz)
     jl_ctx = unsafe_pointer_to_objref(c_ctx)
     jl_msg = pointer_to_array(c_msg, sz, false)
-    n = readbytes!(jl_ctx, jl_msg, sz)
+    n = readbytes!(jl_ctx, jl_msg, Int(sz))
     Cint(n)
 end
 


### PR DESCRIPTION
Still getting a `cannot resize array with shared data`, not sure how to best deal with that. Commenting out the `readbytes!` method that was added in https://github.com/JuliaLang/julia/pull/14667 seems to work, but may reintroduce the perf issue in base. cc @vtjnash

One ugly way to fix this is to change this line to
`n = invoke(readbytes!, (IO, AbstractArray{UInt8}, Any), jl_ctx, jl_msg, sz)`

Or https://github.com/JuliaLang/julia/pull/14699 may change the behavior here. Regardless of the fix, I could use some help writing tests in base that are representative of the way this package needs to use IO functions. First for calling `readbytes!` with a non-`Int` input `nb`, where widening `wait_readnb(x::LibuvStream, nb::Int)` and `wait_readnb(s::BufferStream, nb::Int)` to accept `Integer` should be safe as far as I can tell. I can figure out `BufferStream` (`bufstr = BufferStream(); data = UInt8[0,0,0,0,0]; sz = UInt(5); write(bufstr, data+1); readbytes!(bufstr, data, sz)`) but not sure how to do any of the other `LibuvStream` subtypes. From what I can tell, `jl_ctx` when this package executes its tests is always a `TCPSocket` here.