### PR TITLE
Remove duplicate definitions

### DIFF
--- a/src/cipher.jl
+++ b/src/cipher.jl
@@ -163,13 +163,6 @@ function CipherInfo(id::CipherID)
     end
 end
 
-function CipherInfo(kind::CipherKind)
-    ptr = ccall((:mbedtls_cipher_info_from_type, MBED_CRYPTO), Ptr{Void},
-        (Cint,), Int(kind))
-    ptr == C_NULL && error("No type found for $cipher")
-    CipherInfo(ptr)
-end
-
 function Cipher(info::CipherInfo)
     cipher = Cipher()
     @err_check ccall((:mbedtls_cipher_setup, MBED_CRYPTO), Cint,

--- a/src/pk.jl
+++ b/src/pk.jl
@@ -34,7 +34,7 @@ function parse_public_keyfile!(ctx::PKContext, path)
         ctx.data, path)
 end
 
-function parse_key!(ctx::PKContext, key, maybe_pw=Nullable())
+function parse_key!(ctx::PKContext, key, maybe_pw::Nullable = Nullable())
     key_bs = bytestring(key)
     if isnull(maybe_pw)
         pw = C_NULL


### PR DESCRIPTION
The `CipherInfo` duplicates had slightly different error messages. Other than that they were identical.

The signatures for the `parse_key!` methods were written such that

    parse_key!(ctx::PKContext, key, pw) = parse_key!(ctx, key, Nullable(pw))

calls itself resulting in a stack overflow eventually. Restricting `maybe_pw` in the first method to `Nullable` fixes that.