### PR TITLE
be more specific with unsafe_read/unsafe_write version cutoff

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 environment:
   matrix:
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -134,7 +134,7 @@ function handshake(ctx::SSLContext)
     nothing
 end
 
-if Base.VERSION < v"0.5-"
+if Base.VERSION < v"0.5.0-dev+2301"
     import Base: read, write
     const unsafe_read = read
     const unsafe_write = write


### PR DESCRIPTION
to avoid breaking the package on older 0.5-dev versions, ref #30