### PR TITLE
check mbedtls_version_get_string in libmbedcrypto

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -13,7 +13,7 @@ function validate_mbed(name, handle)
         version >= v"2.1.1"
     catch err
         warn("Could not check MbedTLS version: $err")
-        true
+        false
     end
 end
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -17,8 +17,8 @@ function validate_mbed(name, handle)
     end
 end
 
-mbed = library_dependency("libmbedtls", aliases=["libmbedtls", "libmbedtls.2.1.1"], validate=validate_mbed)
-mbed_crypto = library_dependency("libmbedcrypto", aliases=["libmbedcrypto", "libmbedcrypto.2.1.1"])
+mbed = library_dependency("libmbedtls", aliases=["libmbedtls", "libmbedtls.2.1.1"])
+mbed_crypto = library_dependency("libmbedcrypto", aliases=["libmbedcrypto", "libmbedcrypto.2.1.1"], validate=validate_mbed)
 mbed_x509 = library_dependency("libmbedx509", aliases=["libmbedx509", "libmbedx509.2.1.1"])
 
 mbed_all = [mbed, mbed_crypto, mbed_x509]


### PR DESCRIPTION
`mbedtls_version_get_string` only appears in `libmbedcrypto`
Fixes #49