### PR TITLE
Add ALPN support

### DIFF
--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -5,6 +5,7 @@ type SSLConfig
     dbg
     cert
     key
+    alpn_protos
 
     function SSLConfig()
         conf = new()
@@ -132,6 +133,19 @@ function handshake(ctx::SSLContext)
         (Ptr{Void},), ctx.data)
     ctx.isopen = true
     nothing
+end
+
+function set_alpn!(conf::SSLConfig, protos)
+    conf.alpn_protos = protos
+    @err_check ccall((:mbedtls_ssl_conf_alpn_protocols, MBED_TLS), Cint,
+                     (Ptr{Void}, Ptr{Ptr{Cchar}}), conf.data, protos)
+    nothing
+end
+
+function alpn_proto(ctx::SSLContext)
+    rv = ccall((:mbedtls_ssl_get_alpn_protocol, MBED_TLS), Ptr{Cchar},
+               (Ptr{Void},), ctx.data)
+    String(rv)
 end
 
 if Base.VERSION < v"0.5.0-dev+2301"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,7 +104,7 @@ let
     MbedTLS.handshake(ctx)
 
     write(ctx, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
-    @assert MbedTLS.alpn_proto(ctx) == "h2"
+    @test MbedTLS.alpn_proto(ctx) == "h2"
 end
 
 # Test pk.jl methods


### PR DESCRIPTION
This pull request add ALPN support for the wrapper. According to HTTP/2 spec, this is necessary for negotiating protocols when HTTPS is enabled.

For the test, I used "google.com" because "httpbin.org" doesn't support HTTP/2 for now.