### PR TITLE
Add appropriate lower bounds for BinDeps and Homebrew

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
-BinDeps
+BinDeps 0.4.2
 Compat 0.8.0
-@osx Homebrew
+@osx Homebrew 0.3.3


### PR DESCRIPTION
[ci skip]

Adding the right lower bounds for BinDeps and Homebrew. Should fix most if not all of the dep warns during install. 

cc: @tkelman 