### PR TITLE
Changing types in `parse_key!` call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/pk.jl
+++ b/src/pk.jl
@@ -29,7 +29,7 @@ function parse_keyfile(path, password="")
 end
 
 function parse_public_keyfile!(ctx::PKContext, path)
-    @err_check ccall((:mbedtls_pk_parse_public_keyfile, MBED_TLS), Cint,
+    @err_check ccall((:mbedtls_pk_parse_public_keyfile, MBED_CRYPTO), Cint,
         (Ptr{Void}, Cstring),
         ctx.data, path)
 end

--- a/src/pk.jl
+++ b/src/pk.jl
@@ -44,7 +44,7 @@ function parse_key!(ctx::PKContext, key, maybe_pw::Nullable = Nullable())
         pw_size = sizeof(pw)  # Might be off-by-one
     end
     @err_check ccall((:mbedtls_pk_parse_key, MBED_TLS), Cint,
-        (Ptr{Void}, Ptr{Void}, Csize_t, Ptr{Void}, Csize_t),
+        (Ptr{Void}, Ptr{Cuchar}, Csize_t, Ptr{Cuchar}, Csize_t),
         ctx.data, key_bs, sizeof(key_bs)+1, pw, pw_size)
 end
 

--- a/src/pk.jl
+++ b/src/pk.jl
@@ -43,7 +43,7 @@ function parse_key!(ctx::PKContext, key, maybe_pw::Nullable = Nullable())
         pw = String(get(maybe_pw))
         pw_size = sizeof(pw)  # Might be off-by-one
     end
-    @err_check ccall((:mbedtls_pk_parse_key, MBED_TLS), Cint,
+    @err_check ccall((:mbedtls_pk_parse_key, MBED_CRYPTO), Cint,
         (Ptr{Void}, Ptr{Cuchar}, Csize_t, Ptr{Cuchar}, Csize_t),
         ctx.data, key_bs, sizeof(key_bs)+1, pw, pw_size)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -172,6 +172,12 @@ let
     @test sizeof(output) == MbedTLS.sign!(key, MD_SHA1,
         MbedTLS.digest(MD_SHA1, "MbedTLS.jl"), output, MersenneTwister(0))
     verify_key_pem("MbedTLS.jl", output)
+
+    key_string = read(open("key.pem", "r"))
+    key = MbedTLS.PKContext()
+    MbedTLS.parse_key!(key, key_string)
+    @test MbedTLS.bitlength(key) == 2048
+    @test MbedTLS.get_name(key) == "RSA"
 end
 
 # Test md.jl


### PR DESCRIPTION
Change `Void` pointers to `Cuchar` pointers in line with the signature
of [`mbedtls_pk_parse_key`](https://tls.mbed.org/api/pk_8h.html#a072d27dc4143bfd600786232f9417e08)

Addressing issue #71 