### PR TITLE
Fixed build on ARM platform

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -45,7 +45,7 @@ if is_unix()
             @build_steps begin
                 ChangeDirectory(mbed_dir)
                  @build_steps begin
-                    `cmake -DUSE_SHARED_MBEDTLS_LIBRARY=On .`
+                    `cmake -DUSE_SHARED_MBEDTLS_LIBRARY=On $(Sys.ARCH == :arm ? "-DCMAKE_C_FLAGS=-fomit-frame-pointer" : "") .`
                     `make lib`
                 end
             end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -45,7 +45,7 @@ if is_unix()
             @build_steps begin
                 ChangeDirectory(mbed_dir)
                  @build_steps begin
-                    `cmake -DUSE_SHARED_MBEDTLS_LIBRARY=On $(Sys.ARCH == :arm ? "-DCMAKE_C_FLAGS=-fomit-frame-pointer" : "") .`
+                    `cmake -DUSE_SHARED_MBEDTLS_LIBRARY=On $(length(string(Sys.ARCH)) >= 3 && string(Sys.ARCH)[1:3] == "arm" ? "-DCMAKE_C_FLAGS=-fomit-frame-pointer" : "") .`
                     `make lib`
                 end
             end


### PR DESCRIPTION
On ARM devices the build step fails with
```
[  5%] Building C object library/CMakeFiles/mbedcrypto.dir/bignum.c.o
/root/.julia/v0.5/MbedTLS/deps/src/mbedtls-2.1.1/library/bignum.c: In function ‘mpi_mul_hlp’:
/root/.julia/v0.5/MbedTLS/deps/src/mbedtls-2.1.1/library/bignum.c:1128:1: error: r7 cannot be used in asm here
 }
 ^
```

Additional information can be found here: https://tls.mbed.org/kb/development/arm-thumb-error-r7-cannot-be-used-in-asm-here