### PR TITLE
Check if ctx.config is defined before calling get_version; technicall…

### DIFF
--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -240,8 +240,12 @@ function get_peer_cert(ctx::SSLContext)
 end
 
 function get_version(ctx::SSLContext)
-    data = ccall((:mbedtls_ssl_get_version, MBED_TLS), Ptr{UInt8}, (Ptr{Void},), ctx.data)
-    return unsafe_string(data)
+    if isdefined(ctx, :config)
+        data = ccall((:mbedtls_ssl_get_version, MBED_TLS), Ptr{UInt8}, (Ptr{Void},), ctx.data)
+        return unsafe_string(data)
+    else
+        throw(ArgumentError("`ctx` hasn't been initialized with an MbedTLS.SSLConfig; run `MbedTLS.setup!(ctx, conf)`"))
+    end
 end
 
 function get_ciphersuite(ctx::SSLContext)


### PR DESCRIPTION
…y this can still segfault if the user sets the config without calling setup, but hopefully our error message at least points them in the right direction

Fixes #79