### PR TITLE
add `set_dbg_level`, do not use `String.data`

### DIFF
--- a/src/cipher.jl
+++ b/src/cipher.jl
@@ -192,7 +192,7 @@ function get_key_bitlen(cipher::Cipher)
 end
 
 tobytes(x::Vector{UInt8}) = x
-tobytes(x) = String(x).data
+tobytes(x) = Vector{UInt8}(x)
 
 function set_key!(cipher::Cipher, key, op::Operation)
     key_b = tobytes(key)

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -118,13 +118,26 @@ end
 
 function f_dbg(c_ctx, level, filename, number, msg)
     jl_ctx = unsafe_pointer_to_objref(c_ctx)
-    jl_ctx(level, String(filename), number, String(msg))
+    jl_ctx(level, unsafe_string(filename), number, unsafe_string(msg))
     nothing
 end
 
 function dbg!(conf::SSLConfig, f)
     conf.dbg = f
     dbg!(conf, c_dbg, pointer_from_objref(f))
+    nothing
+end
+
+@enum(DebugThreshold,
+    NONE = 0,
+    ERROR,
+    STATE_CHANGE,
+    INFO,
+    VERBOSE)
+
+function set_dbg_level(level)
+    ccall((:mbedtls_debug_set_threshold, MBED_TLS), Void,
+        (Cint,), Cint(level))
     nothing
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,6 +106,7 @@ let
     end
 
     MbedTLS.dbg!(conf, show_debug)
+    MbedTLS.set_dbg_level(MbedTLS.DebugThreshold(1))
 
     MbedTLS.ca_chain!(conf)
 
@@ -148,6 +149,7 @@ let
     end
 
     MbedTLS.dbg!(conf, show_debug)
+    MbedTLS.set_dbg_level(MbedTLS.DebugThreshold(1))
 
     MbedTLS.ca_chain!(conf)
 
@@ -210,7 +212,7 @@ let
     write(md, UInt8['M', 'b', 'e', 'd'])
     write(md, reinterpret(UInt32, UInt8['T', 'L', 'S', '.'])[])
     write(md, reinterpret(UInt16, UInt8['j','l']))
-    @test MbedTLS.finish!(md) == MbedTLS.digest(MD_SHA1,"MbedTLS.jl".data)
+    @test MbedTLS.finish!(md) == MbedTLS.digest(MD_SHA1,Vector{UInt8}("MbedTLS.jl"))
 
     # Test reset functionality
     md = MbedTLS.MD(MbedTLS.MD_SHA256, "passcode")


### PR DESCRIPTION
- added a new method `set_dbg_level` to manipulate MbedTLS debug threshold
- do not use `String.data`, fixes #94
- fix a deprecation warning in `f_dbg` method