### PR TITLE
Make it easier to call MbedTLS from userimg

### DIFF
--- a/src/MbedTLS.jl
+++ b/src/MbedTLS.jl
@@ -57,6 +57,7 @@ function __init__()
     __sslinit__()
     __entropyinit__()
 end
+__init__()
 
 # using TransportLayerSecurity
 

--- a/src/ctr_drbg.jl
+++ b/src/ctr_drbg.jl
@@ -48,6 +48,7 @@ function Base.rand(rng::CtrDrbg, size::Integer)
     rand!(rng, buf)
 end
 
+const c_rng = Ref{Ptr{Void}}(C_NULL)
 function __ctr_drbg__init__()
-    const global c_rng=cfunction(f_rng, Cint, (Ptr{Void}, Ptr{UInt8}, Csize_t))
+    c_rng[] = cfunction(f_rng, Cint, (Ptr{Void}, Ptr{UInt8}, Csize_t))
 end

--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -33,11 +33,12 @@ end
 
 function add_source!(ctx::Entropy, f, threshold, strong)
     push!(ctx.sources, f)
-    add_source!(ctx, c_entropy, pointer_from_objref(f), threshold, strong ? 1 : 0)
+    add_source!(ctx, c_entropy[], pointer_from_objref(f), threshold, strong ? 1 : 0)
 end
 
+const c_entropy = Ref{Ptr{Void}}(C_NULL)
 function __entropyinit__()
-    global const c_entropy = cfunction(jl_entropy, Cint, (Ptr{Void}, Ptr{Void}, Csize_t, Ptr{Void}))
+    c_entropy[] = cfunction(jl_entropy, Cint, (Ptr{Void}, Ptr{Void}, Csize_t, Ptr{Void}))
 end
 
 function gather(ctx::Entropy)

--- a/src/pk.jl
+++ b/src/pk.jl
@@ -74,7 +74,7 @@ function decrypt!(ctx::PKContext, input, output, rng)
     outlen_ref = Ref{Cint}(0)
     @err_check ccall((:mbedtls_pk_decrypt, MBED_CRYPTO), Cint,
         (Ptr{Void}, Ptr{UInt8}, Csize_t, Ptr{Void}, Ref{Cint}, Csize_t, Ptr{Void}, Ptr{Void}),
-        ctx.data, input, sizeof(input), output, outlen_ref, sizeof(output), c_rng, pointer_from_objref(rng))
+        ctx.data, input, sizeof(input), output, outlen_ref, sizeof(output), c_rng[], pointer_from_objref(rng))
     outlen = outlen_ref[]
     Int(outlen)
 end
@@ -83,7 +83,7 @@ function encrypt!(ctx::PKContext, input, output, rng)
     outlen_ref = Ref{Cint}(0)
     @err_check ccall((:mbedtls_pk_encrypt, MBED_CRYPTO), Cint,
         (Ptr{Void}, Ptr{UInt8}, Csize_t, Ptr{Void}, Ref{Cint}, Csize_t, Ptr{Void}, Ptr{Void}),
-        ctx.data, input, sizeof(input), output, outlen_ref, sizeof(output), c_rng, pointer_from_objref(rng))
+        ctx.data, input, sizeof(input), output, outlen_ref, sizeof(output), c_rng[], pointer_from_objref(rng))
     outlen = outlen_ref[]
     Int(outlen)
 end
@@ -92,7 +92,7 @@ function sign!(ctx::PKContext, hash_alg::MDKind, hash, output, rng)
     outlen_ref = Ref{Csize_t}(sizeof(output))
     @err_check ccall((:mbedtls_pk_sign, MBED_CRYPTO), Cint,
         (Ptr{Void}, Cint, Ptr{UInt8}, Csize_t, Ptr{UInt8}, Ref{Csize_t}, Ptr{Void}, Ptr{Void}),
-        ctx.data, hash_alg, hash, sizeof(hash), output, outlen_ref, c_rng, pointer_from_objref(rng))
+        ctx.data, hash_alg, hash, sizeof(hash), output, outlen_ref, c_rng[], pointer_from_objref(rng))
     outlen = outlen_ref[]
     Int(outlen)
 end

--- a/src/rsa.jl
+++ b/src/rsa.jl
@@ -77,7 +77,7 @@ function verify(ctx::RSA, hash_alg::MDKind, hash, signature, rng = nothing; usin
     @err_check ccall((:mbedtls_rsa_pkcs1_verify, MBED_CRYPTO), Cint,
         (Ptr{Void}, Ptr{Void}, Ptr{Void}, Cint, Cint, Csize_t, Ptr{UInt8}, Ptr{UInt8}),
         ctx.data,
-        rng == nothing ? C_NULL : c_rng,
+        rng == nothing ? C_NULL : c_rng[],
         rng == nothing ? C_NULL : pointer_from_objref(rng),
         using_public ? 0 : 1,
         hash_alg, sizeof(hash), hash, signature)
@@ -94,7 +94,7 @@ end
 
 function gen_key(rng::AbstractRNG, nbits=2048, exponent=65537)
     ctx = RSA()
-    gen_key!(ctx, c_rng, pointer_from_objref(rng), nbits, exponent)
+    gen_key!(ctx, c_rng[], pointer_from_objref(rng), nbits, exponent)
     ctx
 end
 
@@ -112,5 +112,5 @@ function private(ctx::RSA, f_rng, p_rng, input, output)
 end
 
 function private(ctx::RSA, rng::AbstractRNG, input, output)
-    private(ctx, c_rng, pointer_from_objref(rng), input, output)
+    private(ctx, c_rng[], pointer_from_objref(rng), input, output)
 end


### PR DESCRIPTION
Rather than delay-setting constants, create global refs and just update
the pointers in the init method.