### PR TITLE
Explicitly import Libdl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,7 @@
 using Compat
+if VERSION >= v"0.7.0-DEV.3382"
+    import Libdl
+end
 
 need_to_build_manually = true
 


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/25459 moved `Libdl` to the stdlib, which means that we need to explicitly import it now before we can do things like `Libdl.dlopen()`.

Note that this is essentially a no-op on Julia 0.6, so this shouldn't break anything.  (We'll see if CI agrees with me there)