### PR TITLE
Base.rand is now Random.rand

### DIFF
--- a/src/MbedTLS.jl
+++ b/src/MbedTLS.jl
@@ -9,6 +9,8 @@ end
 
 @static if VERSION >= v"0.7.0-DEV.3406"
     using Random
+else
+    const Random = Base.Random
 end
 
 if !applicable(contains, "", r"")

--- a/src/ctr_drbg.jl
+++ b/src/ctr_drbg.jl
@@ -34,14 +34,14 @@ end
 
 seed!(rng::CtrDrbg, entropy) = seed!(rng, entropy, UInt8[])
 
-function Base.rand!(rng::CtrDrbg, buf::Array)
+function Random.rand!(rng::CtrDrbg, buf::Array)
     @err_check ccall((:mbedtls_ctr_drbg_random, MBED_CRYPTO), Cint,
             (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
         rng.data, buf, sizeof(buf))
     buf
 end
 
-function Base.rand(rng::CtrDrbg, size::Integer)
+function Random.rand(rng::CtrDrbg, size::Integer)
     buf = Vector{UInt8}(uninitialized, size)
     rand!(rng, buf)
 end


### PR DESCRIPTION
https://travis-ci.org/JuliaWeb/HTTP.jl/jobs/329829116#L1767

```
HTTP: Error During Test at /Users/sam/julia/v0.7/HTTP/test/runtests.jl:11
  Got an exception of type LoadError outside of a @test
  LoadError: ArgumentError: Sampler for this object is not defined
  Stacktrace:
   [1] Type at /Users/sam/julia/julia/usr/share/julia/site/v0.7/Random/src/Random.jl:114 [inlined]
   [2] rand at /Users/sam/julia/julia/usr/share/julia/site/v0.7/Random/src/Random.jl:201 [inlined]
   [3] rand! at /Users/sam/julia/julia/usr/share/julia/site/v0.7/Random/src/Random.jl:218 [inlined]
   [4] rand! at /Users/sam/julia/julia/usr/share/julia/site/v0.7/Random/src/Random.jl:214 [inlined] (repeats 2 times)
   [5] f_rng(::MbedTLS.CtrDrbg, ::Ptr{UInt8}, ::UInt64) at /Users/sam/.julia/v0.7/MbedTLS/src/ctr_drbg.jl:22
   [6] macro expansion at /Users/sam/.julia/v0.7/MbedTLS/src/error.jl:3 [inlined]
   [7] handshake(::MbedTLS.SSLContext) at /Users/sam/.julia/v0.7/MbedTLS/src/ssl.jl:163
   [8] handshake! at /Users/sam/.julia/v0.7/MbedTLS/src/MbedTLS.jl:109 [inlined]
   [9] #getconnection#12(::Bool, ::MbedTLS.SSLConfig, ::Base.Iterators.IndexValue{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:iofunction, :verbose),Tuple{getfield(HTTP.WebSockets, Symbol("##3#4")){Bool,getfield(, Symbol("##68#69")),String},Int64}}}, ::Function, ::Type{MbedTLS.SSLContext}, ::SubString{String}, ::SubString{String}) at /Users/sam/.julia/v0.7/HTTP/src/ConnectionPool.jl:535
```