### PR TITLE
Require julia 0.6.2

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
+julia 0.6.2
 BinaryProvider
 Compat 0.52.0


### PR DESCRIPTION
[This check](https://github.com/JuliaWeb/MbedTLS.jl/blob/21210b79b43d5e7516e5109ae4318b102b4aa0a7/src/MbedTLS.jl#L10-L12) returns true on Julia 0.6.0 (at least), which breaks `using MbedTLS`.

Ref: https://github.com/JunoLab/Atom.jl/issues/117

Should also change the version bound in METADATA, I guess.