### PR TITLE
fix missing string comparison in build.jl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -33,7 +33,7 @@ download_info = Dict(
 )
 
 # First, check to see if we're all satisfied
-if any(!satisfied(p; verbose=verbose) for p in products) || get(ENV, "FORCE_BUILD", "false")
+if any(!satisfied(p; verbose=verbose) for p in products) || get(ENV, "FORCE_BUILD", "false") != "true"
     if haskey(download_info, platform_key()) && get(ENV, "FORCE_BUILD", "false") != "true" && !haskey(ENV, "USE_GPL_MBEDTLS")
         # Download and install binaries
         url, tarball_hash = download_info[platform_key()]


### PR DESCRIPTION
Currently the build fails for me with:

```
LoadError: TypeError: non-boolean (String) used in boolean context
while loading /home/rdeits/locomotion/explorations/learning-mpc-2/packages/v0.6/MbedTLS/deps/ starting on line 36
```

because line 36 returns the string "false" instead of a boolean. This PR fixes the error. 