### PR TITLE
Check for close_notify message in Base.isopen(ctx::SSLContext)

### DIFF
--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -180,14 +180,13 @@ function handshake(ctx::SSLContext)
     end
     ctx.isopen = true
 
-    @schedule while ctx.isopen && isopen(ctx.bio)
+    @schedule while isopen(ctx)
         # Ensure that libuv is reading data from the socket in case the peer
         # has sent a close_notify message on an otherwise idle connection.
         # https://tools.ietf.org/html/rfc5246#section-7.2.1
         Base.start_reading(ctx.bio)
         wait(ctx.bio.readnotify)
         yield()
-        decrypt_available_bytes(ctx)
     end
 
     return


### PR DESCRIPTION
This change enables `Base.isopen(ctx::SSLContext)` to detect that the peer has closed an idle connection.

Before this change an idle TLS connection could receive a [`close_notify`](https://tools.ietf.org/html/rfc5246#section-7.2.1) message from the TLS peer, but we would never notice it because the `LibuvStream` was no longer in `StatusActive` so the message never found its way into the read buffer.

This appears to be the root cause of various EOFError() issues related to re-use of idle connections:
https://github.com/JuliaWeb/HTTP.jl/issues/214
https://github.com/JuliaWeb/HTTP.jl/issues/199
https://github.com/JuliaWeb/HTTP.jl/issues/220
https://github.com/JuliaWeb/GitHub.jl/issues/106

This change modifies `Base.isopen(ctx::SSLContext)` to:
 - call `Base.start_reading(ctx.bio); yield()` to ensure that the `LibuvStream` is active,
 - do a zero-byte `mbedtls_ssl_read` to ensure that the `close_notify` message is processed by the TLS library if it has been received,
 - check return code of the zero-byte read for `MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY`

Note that the [`idle_timeout=` change to GitHub.jl](https://github.com/JuliaWeb/GitHub.jl/pull/109) is still desirable because there is a race-condition when a request is sent on an idle connection at the same moment that the server decides to send `close_notify` and drop the connection.