### PR TITLE
WIP: Replace  Base.start_reading(ctx.bio) task with Monitor Task

### DIFF
--- a/src/MbedTLS.jl
+++ b/src/MbedTLS.jl
@@ -13,6 +13,8 @@ end
     end
 end
 
+const DEBUG_LEVEL = 0
+
 export
 # Message digests
     MD_NONE,

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -1,3 +1,5 @@
+# Data Structures
+
 mutable struct SSLConfig
     data::Ptr{Cvoid}
     rng
@@ -26,12 +28,19 @@ mutable struct SSLContext <: IO
     datalock::ReentrantLock
     config::SSLConfig
     isopen::Bool
+    close_notify_sent::Bool
+    decrypted_data_wanted::Condition
+    decrypted_data_ready::Condition
     bio
 
     function SSLContext()
         ctx = new()
         ctx.data = Libc.malloc(1000)  # 488
         ctx.datalock = ReentrantLock()
+        ctx.isopen = false
+        ctx.close_notify_sent = false
+        ctx.decrypted_data_wanted = Condition()
+        ctx.decrypted_data_ready = Condition()
         ccall((:mbedtls_ssl_init, libmbedtls), Cvoid, (Ptr{Cvoid},), ctx.data)
         @compat finalizer(ctx->begin
             ccall((:mbedtls_ssl_free, libmbedtls), Cvoid, (Ptr{Cvoid},), ctx.data)
@@ -52,6 +61,9 @@ macro lockdata(ctx, expr)
         end
     end)
 end
+
+
+# Configuration
 
 function config_defaults!(config::SSLConfig; endpoint=MBEDTLS_SSL_IS_CLIENT,
     transport=MBEDTLS_SSL_TRANSPORT_STREAM, preset=MBEDTLS_SSL_PRESET_DEFAULT)
@@ -109,21 +121,43 @@ function set_bio!(ssl_ctx::SSLContext, ctx, f_send::Ptr{Cvoid}, f_recv::Ptr{Cvoi
     end
 end
 
+
+# Debug
+
+
+@static if DEBUG_LEVEL > 0
+    using Dates
+    taskid(t=current_task()) = string(hash(t) & 0xffff, base=16, pad=4)
+    debug_header() = string("MBTLS: ", rpad(Dates.now(), 24), taskid(), " ")
+end
+
+macro debug(n::Int, s)
+    DEBUG_LEVEL >= n ? :(println(debug_header(), $(esc(s)))) :
+                       :()
+end
+
+macro 💀(s) :( @debug 1 $(esc(s)) ) end
+macro 😬(s) :( @debug 2 $(esc(s)) ) end
+macro 🤖(s) :( @debug 3 $(esc(s)) ) end
+
+
+# Low level Encrypted IO Callbacks
+
 function f_send(c_ctx, c_msg, sz)
-    jl_ctx = unsafe_pointer_to_objref(c_ctx)
-    !isopen(jl_ctx.bio) && return Cint(MBEDTLS_ERR_NET_CONN_RESET)
+    jl_ctx = unsafe_pointer_to_objref(c_ctx)                                    ;@🤖 "f_send ➡️  $sz"
     return Cint(unsafe_write(jl_ctx.bio, c_msg, sz))
 end
 
 function f_recv(c_ctx, c_msg, sz)
+    @assert sz > 0
     jl_ctx = unsafe_pointer_to_objref(c_ctx)
     n = bytesavailable(jl_ctx.bio)
     if n == 0
         return isopen(jl_ctx.bio) ? Cint(MBEDTLS_ERR_SSL_WANT_READ) :
-                    jl_ctx.isopen ? Cint(MBEDTLS_ERR_NET_CONN_RESET) :
-                                    Cint(n)
+        !jl_ctx.close_notify_sent ? Cint(MBEDTLS_ERR_NET_CONN_RESET) :
+                                    Cint(0)
     end
-    n = min(sz, n)
+    n = min(sz, n)                                                              ;@🤖 "f_recv ⬅️  $n"
     unsafe_read(jl_ctx.bio, c_msg, n)
     return Cint(n)
 end
@@ -133,6 +167,9 @@ function set_bio!(ssl_ctx::SSLContext, jl_ctx::T) where {T<:IO}
     set_bio!(ssl_ctx, pointer_from_objref(ssl_ctx), c_send[], c_recv[])
     nothing
 end
+
+
+# Debug
 
 function dbg!(conf::SSLConfig, f::Ptr{Cvoid}, p)
     ccall((:mbedtls_ssl_conf_dbg, libmbedtls), Cvoid,
@@ -164,10 +201,13 @@ function set_dbg_level(level)
     nothing
 end
 
-Base.wait(ctx::SSLContext) = (eof(ctx.bio); nothing)
-                             # eof blocks if the receive buffer is empty
+
+# Handshake
 
 function handshake(ctx::SSLContext)
+
+    ctx.isopen && throw(ArgumentError("handshake() already done!"))
+                                                                                ;@😬 "🤝 ..."
     while true
         n = @lockdata ctx begin
             ccall((:mbedtls_ssl_handshake, libmbedtls), Cint,
@@ -176,53 +216,97 @@ function handshake(ctx::SSLContext)
         if n == 0
             break
         end
-        if n != MBEDTLS_ERR_SSL_WANT_READ
+        if n == MBEDTLS_ERR_SSL_WANT_READ                                       ;@😬 "🤝  ⌛️"
+            if eof(ctx.bio)
+                throw(EOFError())                                               ;@💀 "🤝  💥"
+            end
+        else
             mbed_err(n)
         end
-        wait(ctx)
     end
+                                                                                ;@😬 "🤝  ✅"
     ctx.isopen = true
 
     @static if VERSION < v"0.7.0-alpha.0"
-        @schedule while isopen(ctx)
-            # Ensure that libuv is reading data from the socket in case the peer
-            # has sent a close_notify message on an otherwise idle connection.
-            # https://tools.ietf.org/html/rfc5246#section-7.2.1
-            Base.start_reading(ctx.bio)
-            try
-                wait(ctx.bio.readnotify)
-            catch e
-                if e isa Base.UVError
-                    # Ignore read errors (UVError ECONNRESET)
-                    # https://github.com/JuliaWeb/MbedTLS.jl/issues/148
-                else
-                    rethrow(e)
-                end
-            end
-            yield()
-        end
+        @schedule monitor(ctx)
     else
-        @async while isopen(ctx)
-            # Ensure that libuv is reading data from the socket in case the peer
-            # has sent a close_notify message on an otherwise idle connection.
-            # https://tools.ietf.org/html/rfc5246#section-7.2.1
-            Base.start_reading(ctx.bio)
-            try
-                wait(ctx.bio.readnotify)
-            catch e
-                if e isa Base.UVError
-                    # Ignore read errors (UVError ECONNRESET)
-                    # https://github.com/JuliaWeb/MbedTLS.jl/issues/148
-                else
-                    rethrow(e)
-                end
-            end
-            yield()
-        end
+        @async    monitor(ctx)
     end
 
     return
 end
+
+
+# Connection Monitoring
+
+"""
+    monitor(::SSLContext)
+
+For as long as the SSLContext is open:
+ - Notify readers (blocked in eof()) when decrypted data is available.
+ - Check the TLS buffers for encrypted data that needs to be processed.
+   (zero-byte ssl_read(), see https://esp32.com/viewtopic.php?t=1101#p4884)
+ - If the peer sends a close_notify message or closes then TCP connection,
+   then notify readers and close the SSLContext.
+ - Wait for more encrypted data to arrive.
+
+State management:
+ - `ctx.isopen` is set `false` when `unsafe_read` or `monitor` throw an error
+    or when the `monitor` determines that the peer has closed the connection.
+ - `close(::TCPSocket)` is called only at the end of the `monitor` loop.
+ - `close(::SSLContext)` just calls `ssl_close_notify`.
+"""
+function monitor(ctx::SSLContext)
+
+    @assert ctx.isopen
+
+    try
+        while ctx.isopen
+
+            n_decrypted = ssl_get_bytes_avail(ctx)                              ;@🤖 "mon 📥  $n_decrypted"
+            if n_decrypted > 0
+                notify(ctx.decrypted_data_ready);                               ;@🤖 "mon 🗣"
+                yield()
+            end
+
+            if (n_decrypted == 0 && ssl_check_pending(ctx)) ||  (                @🤖 "mon ⌛️";
+                                             !eof(ctx.bio))                     ;@🤖 "mon 👁"
+                n = ssl_read(ctx, C_NULL, 0)
+                if n == MBEDTLS_ERR_SSL_WANT_READ ||
+                   ssl_get_bytes_avail(ctx) > n_decrypted
+                    continue                                                    ;@🤖 "mon 🔄"
+                elseif n == 0 && n_decrypted > 0                                ;@🤖 "mon 🔔"
+                    notify(ctx.decrypted_data_ready)                            ;@🤖 "mon 💤"
+                    wait(ctx.decrypted_data_wanted)
+                else
+                    ctx.isopen = false
+                    if n == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY
+                        notify(ctx.decrypted_data_ready)                        ;@🤖 "mon 🗣  🛑"
+                    else
+                        notify_error(ctx, MbedException(n))                     ;@🤖 "mon 🗣  💥"
+                    end
+                end
+            end
+
+            if !isopen(ctx.bio);
+                ctx.isopen = false                                              ;@🤖 "mon 🗣  🗑"
+                notify(ctx.decrypted_data_ready)
+            end
+        end
+    catch e
+        ctx.isopen = false                                                      ;@🤖 "mon 💥  $e"
+        notify_error(ctx, e)
+        rethrow(e)
+    finally
+        close(ctx.bio)                                                          ;@🤖 "mon 🗑"
+    end
+end
+
+notify_error(ctx::SSLContext, e) = notify(ctx.decrypted_data_ready, e;
+                                          all=true, error=true)
+
+
+# ALPN Configuration
 
 function set_alpn!(conf::SSLConfig, protos)
     conf.alpn_protos = protos
@@ -237,16 +321,13 @@ function alpn_proto(ctx::SSLContext)
     unsafe_string(rv)
 end
 
-import Base: unsafe_read, unsafe_write
+
+# IO Interface
 
 function Base.unsafe_write(ctx::SSLContext, msg::Ptr{UInt8}, N::UInt)
-    nw = 0
+    nw = 0                                                                      ;@🤖 "ssl_write ➡️  $N"
     while nw < N
-        ret = @lockdata ctx begin
-            ccall((:mbedtls_ssl_write, libmbedtls), Cint,
-                  (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
-                  ctx.data, msg, N - nw)
-        end
+        ret = ssl_write(ctx, msg, N - nw)
         ret < 0 && mbed_err(ret)
         nw += ret
         msg += ret
@@ -256,91 +337,92 @@ end
 
 Base.write(ctx::SSLContext, msg::UInt8) = write(ctx, Ref(msg))
 
-function Base.unsafe_read(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt; err=true)
+Base.unsafe_read(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt) =
+    (ssl_unsafe_read(ctx, buf, nbytes); nothing)
+
+function ssl_unsafe_read(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt;
+                         error_on_close::Bool=true, wait_for_nbytes::Bool=true)
     nread::UInt = 0
-    while nread < nbytes
-        n = @lockdata ctx begin
-            ccall((:mbedtls_ssl_read, libmbedtls), Cint,
-                   (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
-                   ctx.data, buf + nread, nbytes - nread)
+    try
+        while nread < nbytes
+
+            n = ssl_read(ctx, buf + nread, nbytes - nread)                      ;@😬 "ssl_read ⬅️  $n"
+
+            if n == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY || n == 0
+                ctx.isopen = false                                              ;@😬 "ssl_read 🛑"
+                if error_on_close
+                    throw(EOFError())
+                else
+                    break
+                end
+            elseif n == MBEDTLS_ERR_SSL_WANT_READ
+                if wait_for_nbytes;                                             ;@🤖 "ssl_read 🗣"
+                    notify(ctx.decrypted_data_wanted)                           ;@😬 "ssl_read ⌛️"
+                    wait(ctx.decrypted_data_ready)
+                else
+                    break
+                end
+            elseif n < 0
+                mbed_err(n)
+            else
+                nread += n
+            end
         end
-        if n == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY || n == 0
-            close(ctx)
-            err ? throw(EOFError()) : return nread
-        elseif n == MBEDTLS_ERR_SSL_WANT_READ
-            wait(ctx)
-        elseif n < 0
-            mbed_err(n)
-        else
-            nread += n
-        end
+    catch e
+        ctx.isopen = false                                                      ;@💀 "ssl_read 💥"
+        rethrow(e)
     end
+    return nread
 end
 
-Base.readbytes!(ctx::SSLContext, buf::Vector{UInt8}, nbytes=length(buf)) = readbytes!(ctx, buf, UInt(nbytes))
-function Base.readbytes!(ctx::SSLContext, buf::Vector{UInt8}, nbytes::UInt)
-    nr = unsafe_read(ctx, pointer(buf), nbytes; err=false)
-    if nr !== nothing
-        resize!(buf, nr::UInt)
-    else
-        nr = nbytes
-    end
+Base.readbytes!(ctx::SSLContext, buf::Vector{UInt8}, nbytes=length(buf); kw...) = readbytes!(ctx, buf, UInt(nbytes); kw...)
+
+function Base.readbytes!(ctx::SSLContext, buf::Vector{UInt8}, nbytes::UInt; all::Bool=true)
+    nr = ssl_unsafe_read(ctx, pointer(buf), nbytes; error_on_close=false,
+                                                    wait_for_nbytes=all)        ;@😬 "readbytes! ⬅️  $nr"
     return Int(nr::UInt)
 end
 
-Base.readavailable(ctx::SSLContext) = read(ctx, bytesavailable(ctx))
-
-function Base.eof(ctx::SSLContext)
-    bytesavailable(ctx)>0 && return false
-    return eof(ctx.bio) && bytesavailable(ctx) == 0
+function Base.readavailable(ctx::SSLContext)
+    buf = Vector{UInt8}(undef, MBEDTLS_SSL_MAX_CONTENT_LEN)
+    nr = ssl_unsafe_read(ctx, pointer(buf), UInt(MBEDTLS_SSL_MAX_CONTENT_LEN);
+                         error_on_close=false, wait_for_nbytes=false)           ;@😬 "readavailable ⬅️  $nr"
+    return resize!(buf, nr)
 end
 
-function Base.close(ctx::SSLContext)
-    @lockdata ctx begin
-        if isopen(ctx.bio)
-            try
-                # This is ugly, but a harmless broken pipe exception will be
-                # thrown if the peer closes the connection without responding
-                ccall((:mbedtls_ssl_close_notify, libmbedtls),
-                       Cint, (Ptr{Cvoid},), ctx.data)
-            catch
-            end
-            close(ctx.bio)
-        end
-        ctx.isopen = false
+function Base.eof(ctx::SSLContext)
+    while (n = ssl_get_bytes_avail(ctx) == 0)                                   ;@🤖 "eof $n  📥"
+        if !ctx.isopen                                                          ;@💀 "eof true"
+            return true
+        end                                                                     ;@🤖 "eof 🗣"
+        notify(ctx.decrypted_data_wanted)                                       ;@😬 "eof ⌛️"
+        wait(ctx.decrypted_data_ready)
+    end                                                                         ;@😬 "eof false"
+    return false
+end
+
+function Base.close(ctx::SSLContext)                                            ;@💀 "close isopen=$(ctx.isopen), " *
+                                                                                               "$(isopen(ctx.bio))"
+    if !ctx.close_notify_sent && ctx.isopen && isopen(ctx.bio)
+        ctx.close_notify_sent = true
+        # This is ugly, but a harmless broken pipe exception will be
+        # thrown if the peer closes the connection without responding
+        # FIXME need to reproduce this and handle a specific error.
+        # try
+            ssl_close_notify(ctx)                                               ;@💀 "close 🗣"
+        # catch e
+        #     if !(e isa XXX) || e.code != YYY
+        #         rethrow(e)
+        #     end
+        #end
     end
     nothing
 end
 
-function Base.isopen(ctx::SSLContext)
+Base.isopen(ctx::SSLContext) = ctx.isopen && !ctx.close_notify_sent
 
-    if !ctx.isopen || !isopen(ctx.bio)
-        return false
-    end
 
-    decrypt_available_bytes(ctx)
-
-    return ctx.isopen && isopen(ctx.bio)
-end
-
-function decrypt_available_bytes(ctx::SSLContext)
-
-    # Zero-byte read causes MbedTLS to call f_recv (always non-blocking)
-    # and decrypt any bytes that are already in the LibuvStream read buffer.
-    # https://esp32.com/viewtopic.php?t=1101#p4884
-    n = @lockdata ctx begin
-        ccall((:mbedtls_ssl_read, libmbedtls), Cint,
-              (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
-                 ctx.data,     C_NULL,       0)
-    end
-    if n == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY
-        close(ctx)
-    elseif n == MBEDTLS_ERR_SSL_WANT_READ
-        # ignore
-    elseif n < 0
-        mbed_err(n)
-    end
-end
+# C API
 
 function get_peer_cert(ctx::SSLContext)
     data = ccall((:mbedtls_ssl_get_peer_cert, libmbedtls), Ptr{Cvoid}, (Ptr{Cvoid},), ctx.data)
@@ -362,21 +444,45 @@ function get_ciphersuite(ctx::SSLContext)
 end
 
 @static if isdefined(Base, :bytesavailable)
-    Base.bytesavailable(ctx::SSLContext) = _bytesavailable(ctx)
+    Base.bytesavailable(ctx::SSLContext) = ssl_get_bytes_avail(ctx)
 else
-    Base.nb_available(ctx::SSLContext) = _bytesavailable(ctx)
+    Base.nb_available(ctx::SSLContext) = ssl_get_bytes_avail(ctx)
 end
 
-function _bytesavailable(ctx::SSLContext)
-
-    decrypt_available_bytes(ctx)
-
+function ssl_get_bytes_avail(ctx::SSLContext)::Int
     @lockdata ctx begin
+        return ccall((:mbedtls_ssl_get_bytes_avail, libmbedtls),
+                     Csize_t, (Ptr{Cvoid},), ctx.data)
+    end
+end
 
-        # Now that the bufferd bytes have been processed, find out how many
-        # decrypted bytes are available.
-        return Int(ccall((:mbedtls_ssl_get_bytes_avail, libmbedtls),
-                         Csize_t, (Ptr{Cvoid},), ctx.data))
+function ssl_check_pending(ctx::SSLContext)::Bool
+    @lockdata ctx begin
+        return ccall((:mbedtls_ssl_check_pending, libmbedtls),
+                     Cint, (Ptr{Cvoid},), ctx.data) > 0
+    end
+end
+
+function ssl_read(ctx::SSLContext, ptr, n)::Int
+    @lockdata ctx begin
+        return ccall((:mbedtls_ssl_read, libmbedtls), Cint,
+                     (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
+                     ctx.data, ptr, n)
+    end
+end
+
+function ssl_write(ctx::SSLContext, ptr, n)::Int
+    @lockdata ctx begin
+        return ccall((:mbedtls_ssl_write, libmbedtls), Cint,
+                     (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
+                     ctx.data, ptr, n)
+    end
+end
+
+function ssl_close_notify(ctx::SSLContext)
+    @lockdata ctx begin
+        return ccall((:mbedtls_ssl_close_notify, libmbedtls),
+                     Cint, (Ptr{Cvoid},), ctx.data)
     end
 end
 

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -491,7 +491,9 @@ function hostname!(ctx::SSLContext, hostname)
       (Ptr{Cvoid}, Cstring), ctx.data, hostname)
 end
 
+if isdefined(Compat, :Sockets)
 Compat.Sockets.getsockname(ctx::SSLContext) = Compat.Sockets.getsockname(ctx.bio)
+end
 
 const c_send = Ref{Ptr{Cvoid}}(C_NULL)
 const c_recv = Ref{Ptr{Cvoid}}(C_NULL)


### PR DESCRIPTION
This is an attempt to address a problem of intermittent hang-ups when doing large volumes of AWS API calls through AWSCore and HTTP.jl.

One manifestation of the problem occurred after several HTTP Transactions with non-trivial size Response Body had already occurred on a connection. The server would send a final 5-byte `0\r\n\r\n` end-of-chunked-body marker. A tiny packet compared to the previous steady stream of body packets. Somehow or other this last packet was never seen by the TLS layer. They HTTP layer was waiting in `eof(::TCPSocket)` but never waking up. It is possible that a Delayed ACK / Naggle interaction caused this last backed to be delayed a bit (Linux client).

Somehow this timing difference seems to have resulted in a race-condition whereby eof() goes to sleep even though there is data waiting. Setting up an async task to trigger when the hang-up had gone on for 2 seconds allowed us to see that the data was, at that point available in the TLS buffer, event though right before going into eof() it was not there.

[A while, back](https://github.com/JuliaWeb/MbedTLS.jl/commit/37bca395354b1172d5720294abf215261909ea42)  we added this `Base.start_reading` band-aid to try to keep libuv watching the socket so that we don't miss TLS close_notify messages when no one is reading from the connection:
https://github.com/JuliaWeb/MbedTLS.jl/blob/7ee7901442c5d9d3b80088244977033a5f7a4ff9/src/ssl.jl#L186-L202

It seems likely that some interaction between the `isopen(ctx)` call above and the going-into-eof code is causing the problem.

There are a few bad smells around. First, the original design of the library didn't really account for OOB messages like TLS close_notify (and other internal TLS messages that client and server may send to each other). This is why we ended up with the `@async while isopen(ctx)` loop above, and is also the reason for some convoluted code to do zero-length reads (which pump the TLS library's internal state) before doing bytes available queries. Another aspect of this that seems not quite is the fact that `eof(::SSLContext)` calls `eof(::TCPSocket)` directly. It all feels a bunch of work-arounds for an initial assumption that there would be more of a 1-1 correspondence between encrypted data arriving and decrypted data being ready to read. In face some encrypted data does not lead to decrypted data at all (OOB messages) and sometimes encrypted data has to accumulate more before it can be decrypted.

This PR removes the `@async while isopen(ctx)` loop and instead implements a `monitor` function who's job it is to watch the state of the connection, do zero-length reads as needed to pump the TLS state machine, and respond gracefully to TLS close_notify messages.

The docstring says:

>For as long as the SSLContext is open:
> - Notify readers (blocked in eof()) when decrypted data is available.
> - Check the TLS buffers for encrypted data that needs to be processed.
>   (zero-byte ssl_read(), see https://esp32.com/viewtopic.php?t=1101#p4884)
> - If the peer sends a close_notify message or closes then TCP connection,
>   then notify readers and close the SSLContext.
 >- Wait for more encrypted data to arrive.

>State management:
> - `ctx.isopen` is set `false` when `unsafe_read` or `monitor` throw an error
>    or when the `monitor` determines that the peer has closed the connection.
> - `close(::TCPSocket)` is called only at the end of the `monitor` loop.
> - `close(::SSLContext)` just calls `ssl_close_notify`.

### Summary of Changes

A `decrypted_data_ready::Condition` is added to the `SSLContext` struct so that `eof(::SSLContect)` now does `wait(ctx.decrypted_data_ready)` instead of `eof(::TCPSocket)`.

A `decrypted_data_wanted::Condition` allows readers to wake up the `monitor` in the event that it has gone to sleep because the TLS read buffer filled up while no one was reading.

`close_notify_sent` flag is added to keep track of the case where our side has asked for the connection to be closed.

A few of the `ccalls` have been pushed into wrapper functions (and the `@lockdata ctx begin` has been pushed into the wrapper functions too, to make the call-sites a bit easier to read).

When `ssl_unsafe_read` needs to wait for more data, it no longer waits on the `TCPSocket`, it waits on the `ctx.decrypted_data_ready` condition.

`Base.readavailable` no longer calls `bytesavailable` to decide how much to read. Instead it creates a buffer for MBEDTLS_SSL_MAX_CONTENT_LEN bytes (16k) and reads as much as it can into that. This removes the old behaviour of first doing a zero-length read to figure out how many bytes are available and then reading that many bytes. The revised scheme should be more efficient because it allows for reading more bytes that might arrive while the read loop is running. Most reads end up being very close to 16k once a connection settles down to a steady streaming state.

`Base.isopen` no longer looks at the `TCPSocket` open state. It only looks at the internal flags `ctx.isopen && !ctx.close_notify_sent`. Closing the `TCPSocket`, and caring if it is closed is up to the `monitor`.

`Base.close` no longer closes the `TCPSocket`, it just sends a TLS close_notify and set the `ctx.close_notify_sent` flag. It is up to the `monitor` to close the socket.

(and it doesn't get hung up anymore in my tests).
(but I am yet to try it out in more varied contexts aside from the one test case I've been focussing on, so it should be considered a WIP)