### PR TITLE
Resolve #174 - Step 1. Cosmetic Changes 

### DIFF
--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -1,3 +1,5 @@
+# Data Structures
+
 mutable struct SSLConfig
     data::Ptr{Cvoid}
     rng
@@ -53,119 +55,8 @@ macro lockdata(ctx, expr)
     end)
 end
 
-function config_defaults!(config::SSLConfig; endpoint=MBEDTLS_SSL_IS_CLIENT,
-    transport=MBEDTLS_SSL_TRANSPORT_STREAM, preset=MBEDTLS_SSL_PRESET_DEFAULT)
-    @err_check ccall((:mbedtls_ssl_config_defaults, libmbedtls), Cint,
-        (Ptr{Cvoid}, Cint, Cint, Cint),
-        config.data, endpoint, transport, preset)
-end
 
-function authmode!(config::SSLConfig, auth)
-    ccall((:mbedtls_ssl_conf_authmode, libmbedtls), Cvoid,
-        (Ptr{Cvoid}, Cint),
-        config.data, auth)
-end
-
-function rng!(config::SSLConfig, f_rng::Ptr{Cvoid}, rng)
-    ccall((:mbedtls_ssl_conf_rng, libmbedtls), Cvoid,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Any),
-        config.data, f_rng, rng)
-end
-
-function rng!(config::SSLConfig, rng::AbstractRNG)
-    config.rng = rng
-    rng!(config, c_rng[], rng)
-end
-
-function ca_chain!(config::SSLConfig, chain=crt_parse_file(joinpath(dirname(@__FILE__), "../deps/cacert.pem")))
-    config.chain = chain
-    ccall((:mbedtls_ssl_conf_ca_chain, libmbedtls), Cvoid,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
-        config.data, chain.data, C_NULL)
-end
-
-function own_cert!(config::SSLConfig, cert::CRT, key::PKContext)
-    config.cert = cert
-    config.key = key
-    @err_check ccall((:mbedtls_ssl_conf_own_cert, libmbedtls), Cint,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
-        config.data, cert.data, key.data)
-end
-
-function setup!(ctx::SSLContext, conf::SSLConfig)
-    @lockdata ctx begin
-        ctx.config = conf
-        @err_check ccall((:mbedtls_ssl_setup, libmbedtls), Cint,
-            (Ptr{Cvoid}, Ptr{Cvoid}),
-            ctx.data, conf.data)
-    end
-end
-
-function set_bio!(ssl_ctx::SSLContext, ctx, f_send::Ptr{Cvoid}, f_recv::Ptr{Cvoid})
-    @lockdata ssl_ctx begin
-        ccall((:mbedtls_ssl_set_bio, libmbedtls), Cvoid,
-            (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
-            ssl_ctx.data, ctx, f_send, f_recv, C_NULL)
-    end
-end
-
-function f_send(c_ctx, c_msg, sz)
-    jl_ctx = unsafe_pointer_to_objref(c_ctx)
-    !isopen(jl_ctx.bio) && return Cint(MBEDTLS_ERR_NET_CONN_RESET)
-    return Cint(unsafe_write(jl_ctx.bio, c_msg, sz))
-end
-
-function f_recv(c_ctx, c_msg, sz)
-    jl_ctx = unsafe_pointer_to_objref(c_ctx)
-    n = bytesavailable(jl_ctx.bio)
-    if n == 0
-        return isopen(jl_ctx.bio) ? Cint(MBEDTLS_ERR_SSL_WANT_READ) :
-                    jl_ctx.isopen ? Cint(MBEDTLS_ERR_NET_CONN_RESET) :
-                                    Cint(n)
-    end
-    n = min(sz, n)
-    unsafe_read(jl_ctx.bio, c_msg, n)
-    return Cint(n)
-end
-
-function set_bio!(ssl_ctx::SSLContext, jl_ctx::T) where {T<:IO}
-    ssl_ctx.bio = jl_ctx
-    set_bio!(ssl_ctx, pointer_from_objref(ssl_ctx), c_send[], c_recv[])
-    nothing
-end
-
-function dbg!(conf::SSLConfig, f::Ptr{Cvoid}, p)
-    ccall((:mbedtls_ssl_conf_dbg, libmbedtls), Cvoid,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Any),
-        conf.data, f, p)
-end
-
-function f_dbg(f, level, filename, number, msg)
-    f(level, unsafe_string(filename), number, unsafe_string(msg))
-    nothing
-end
-
-function dbg!(conf::SSLConfig, f)
-    conf.dbg = f
-    dbg!(conf, c_dbg[], f)
-    nothing
-end
-
-@enum(DebugThreshold,
-    NONE = 0,
-    ERROR,
-    STATE_CHANGE,
-    INFO,
-    VERBOSE)
-
-function set_dbg_level(level)
-    ccall((:mbedtls_debug_set_threshold, libmbedtls), Cvoid,
-        (Cint,), Cint(level))
-    nothing
-end
-
-Base.wait(ctx::SSLContext) = (eof(ctx.bio); nothing)
-                             # eof blocks if the receive buffer is empty
+# Handshake
 
 function handshake(ctx::SSLContext)
     while true
@@ -224,21 +115,75 @@ function handshake(ctx::SSLContext)
     return
 end
 
-function set_alpn!(conf::SSLConfig, protos)
-    conf.alpn_protos = protos
-    @err_check ccall((:mbedtls_ssl_conf_alpn_protocols, libmbedtls), Cint,
-                     (Ptr{Cvoid}, Ptr{Ptr{Cchar}}), conf.data, protos)
+
+# Base ::IO Connection State Methods
+
+"""
+Same as `iswritable(ctx)`.
+> "...a closed stream may still have data to read in its buffer,
+>  use eof to check for the ability to read data." [?Base.isopen]
+"""
+function Base.isopen(ctx::SSLContext)
+
+    if !ctx.isopen || !isopen(ctx.bio)
+        return false
+    end
+
+    decrypt_available_bytes(ctx)
+
+    return ctx.isopen && isopen(ctx.bio)
+end
+
+@static if isdefined(Base, :bytesavailable)
+"""
+Number of decrypted bytes waiting in the TLS buffer.
+"""
+Base.bytesavailable(ctx::SSLContext) = _bytesavailable(ctx)
+else
+Base.nb_available(ctx::SSLContext) = _bytesavailable(ctx)
+end
+
+"""
+True if not `isreadable` and there are no more `bytesavailable` to read.
+"""
+function Base.eof(ctx::SSLContext)
+    bytesavailable(ctx)>0 && return false
+    return eof(ctx.bio) && bytesavailable(ctx) == 0
+end
+
+"""
+Send a TLS `close_notify` message to the peer.
+"""
+function Base.close(ctx::SSLContext)
+    @lockdata ctx begin
+        if isopen(ctx.bio)
+            try
+                # This is ugly, but a harmless broken pipe exception will be
+                # thrown if the peer closes the connection without responding
+                ccall((:mbedtls_ssl_close_notify, libmbedtls),
+                       Cint, (Ptr{Cvoid},), ctx.data)
+            catch
+            end
+            close(ctx.bio)
+        end
+        ctx.isopen = false
+    end
     nothing
 end
 
-function alpn_proto(ctx::SSLContext)
-    rv = ccall((:mbedtls_ssl_get_alpn_protocol, libmbedtls), Ptr{Cchar},
-               (Ptr{Cvoid},), ctx.data)
-    unsafe_string(rv)
-end
+Compat.Sockets.getsockname(ctx::SSLContext) = Compat.Sockets.getsockname(ctx.bio)
 
-import Base: unsafe_read, unsafe_write
 
+# Sending Data
+
+"""
+Copy `nbytes` from `buf` to `ctx`.
+
+The TLS library function `ssl_write` is called as many times as needed to send
+all the data. The TLS library encrypts the data and passes it to the `f_send`
+function which sends it to the underlying connection (`ctx.bio`).
+See `f_send` and `set_bio!` below.
+"""
 function Base.unsafe_write(ctx::SSLContext, msg::Ptr{UInt8}, N::UInt)
     nw = 0
     while nw < N
@@ -254,7 +199,29 @@ function Base.unsafe_write(ctx::SSLContext, msg::Ptr{UInt8}, N::UInt)
     return Int(nw)
 end
 
-Base.write(ctx::SSLContext, msg::UInt8) = write(ctx, Ref(msg))
+
+# Sending Encrypted Data
+
+"""
+Copy `nbytes` of encrypted data from `buf` to the underlying `bio` connection.
+"""
+function f_send(c_ctx, c_msg, sz)
+    jl_ctx = unsafe_pointer_to_objref(c_ctx)
+    !isopen(jl_ctx.bio) && return Cint(MBEDTLS_ERR_NET_CONN_RESET)
+    return Cint(unsafe_write(jl_ctx.bio, c_msg, sz))
+end
+
+"""
+Connect `f_send` and `f_recv` callback functions to `SSLContext`.
+"""
+function set_bio!(ssl_ctx::SSLContext, jl_ctx::T) where {T<:IO}
+    ssl_ctx.bio = jl_ctx
+    set_bio!(ssl_ctx, pointer_from_objref(ssl_ctx), c_send[], c_recv[])
+    nothing
+end
+
+
+# Receiving Data
 
 function Base.unsafe_read(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt; err=true)
     nread::UInt = 0
@@ -277,6 +244,43 @@ function Base.unsafe_read(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt; err=tr
     end
 end
 
+
+# Receiving Encrypted Data
+
+"""
+Copy at most `nbytes` of encrypted data to `buf` from the `bio` connection.
+If no encrypted bytes are available return:
+ - `MBEDTLS_ERR_SSL_WANT_READ` if the connection is still open, or
+ - `MBEDTLS_ERR_NET_CONN_RESET` if it is closed.
+"""
+function f_recv(c_ctx, c_msg, sz)
+    jl_ctx = unsafe_pointer_to_objref(c_ctx)
+    n = bytesavailable(jl_ctx.bio)
+    if n == 0
+        return isopen(jl_ctx.bio) ? Cint(MBEDTLS_ERR_SSL_WANT_READ) :
+                    jl_ctx.isopen ? Cint(MBEDTLS_ERR_NET_CONN_RESET) :
+                                    Cint(n)
+    end
+    n = min(sz, n)
+    unsafe_read(jl_ctx.bio, c_msg, n)
+    return Cint(n)
+end
+
+
+# Base ::IO Write Methods
+
+Base.write(ctx::SSLContext, msg::UInt8) = write(ctx, Ref(msg))
+
+
+# Base ::IO Read Methods
+
+"""
+Copy at most `nbytes` of decrypted data from `ctx` into `buf`.
+If `all=true`: wait for sufficient decrypted data to be available.
+Less than `nbytes` may be copied if the peer sends TLS `close_notify` or closes
+the connection.
+Returns number of bytes copied into `buf` (`<= nbytes`).
+"""
 Base.readbytes!(ctx::SSLContext, buf::Vector{UInt8}, nbytes=length(buf)) = readbytes!(ctx, buf, UInt(nbytes))
 function Base.readbytes!(ctx::SSLContext, buf::Vector{UInt8}, nbytes::UInt)
     nr = unsafe_read(ctx, pointer(buf), nbytes; err=false)
@@ -288,39 +292,153 @@ function Base.readbytes!(ctx::SSLContext, buf::Vector{UInt8}, nbytes::UInt)
     return Int(nr::UInt)
 end
 
+"""
+Read available decrypted data from `ctx`,
+but don't wait for more data to arrive.
+
+The amount of decrypted data that can be read at once is limited by
+`MBEDTLS_SSL_MAX_CONTENT_LEN`.
+"""
 Base.readavailable(ctx::SSLContext) = read(ctx, bytesavailable(ctx))
 
-function Base.eof(ctx::SSLContext)
-    bytesavailable(ctx)>0 && return false
-    return eof(ctx.bio) && bytesavailable(ctx) == 0
+
+# Configuration
+
+function config_defaults!(config::SSLConfig; endpoint=MBEDTLS_SSL_IS_CLIENT,
+    transport=MBEDTLS_SSL_TRANSPORT_STREAM, preset=MBEDTLS_SSL_PRESET_DEFAULT)
+    @err_check ccall((:mbedtls_ssl_config_defaults, libmbedtls), Cint,
+        (Ptr{Cvoid}, Cint, Cint, Cint),
+        config.data, endpoint, transport, preset)
 end
 
-function Base.close(ctx::SSLContext)
+function authmode!(config::SSLConfig, auth)
+    ccall((:mbedtls_ssl_conf_authmode, libmbedtls), Cvoid,
+        (Ptr{Cvoid}, Cint),
+        config.data, auth)
+end
+
+function rng!(config::SSLConfig, f_rng::Ptr{Cvoid}, rng)
+    ccall((:mbedtls_ssl_conf_rng, libmbedtls), Cvoid,
+        (Ptr{Cvoid}, Ptr{Cvoid}, Any),
+        config.data, f_rng, rng)
+end
+
+function rng!(config::SSLConfig, rng::AbstractRNG)
+    config.rng = rng
+    rng!(config, c_rng[], rng)
+end
+
+function ca_chain!(config::SSLConfig, chain=crt_parse_file(joinpath(dirname(@__FILE__), "../deps/cacert.pem")))
+    config.chain = chain
+    ccall((:mbedtls_ssl_conf_ca_chain, libmbedtls), Cvoid,
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        config.data, chain.data, C_NULL)
+end
+
+function own_cert!(config::SSLConfig, cert::CRT, key::PKContext)
+    config.cert = cert
+    config.key = key
+    @err_check ccall((:mbedtls_ssl_conf_own_cert, libmbedtls), Cint,
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        config.data, cert.data, key.data)
+end
+
+function setup!(ctx::SSLContext, conf::SSLConfig)
     @lockdata ctx begin
-        if isopen(ctx.bio)
-            try
-                # This is ugly, but a harmless broken pipe exception will be
-                # thrown if the peer closes the connection without responding
-                ccall((:mbedtls_ssl_close_notify, libmbedtls),
-                       Cint, (Ptr{Cvoid},), ctx.data)
-            catch
-            end
-            close(ctx.bio)
-        end
-        ctx.isopen = false
+        ctx.config = conf
+        @err_check ccall((:mbedtls_ssl_setup, libmbedtls), Cint,
+            (Ptr{Cvoid}, Ptr{Cvoid}),
+            ctx.data, conf.data)
     end
+end
+
+function dbg!(conf::SSLConfig, f::Ptr{Cvoid}, p)
+    ccall((:mbedtls_ssl_conf_dbg, libmbedtls), Cvoid,
+        (Ptr{Cvoid}, Ptr{Cvoid}, Any),
+        conf.data, f, p)
+end
+
+function f_dbg(f, level, filename, number, msg)
+    f(level, unsafe_string(filename), number, unsafe_string(msg))
     nothing
 end
 
-function Base.isopen(ctx::SSLContext)
+function dbg!(conf::SSLConfig, f)
+    conf.dbg = f
+    dbg!(conf, c_dbg[], f)
+    nothing
+end
 
-    if !ctx.isopen || !isopen(ctx.bio)
-        return false
+@enum(DebugThreshold,
+    NONE = 0,
+    ERROR,
+    STATE_CHANGE,
+    INFO,
+    VERBOSE)
+
+function set_dbg_level(level)
+    ccall((:mbedtls_debug_set_threshold, libmbedtls), Cvoid,
+        (Cint,), Cint(level))
+    nothing
+end
+
+Base.wait(ctx::SSLContext) = (eof(ctx.bio); nothing)
+                             # eof blocks if the receive buffer is empty
+
+function set_alpn!(conf::SSLConfig, protos)
+    conf.alpn_protos = protos
+    @err_check ccall((:mbedtls_ssl_conf_alpn_protocols, libmbedtls), Cint,
+                     (Ptr{Cvoid}, Ptr{Ptr{Cchar}}), conf.data, protos)
+    nothing
+end
+
+function alpn_proto(ctx::SSLContext)
+    rv = ccall((:mbedtls_ssl_get_alpn_protocol, libmbedtls), Ptr{Cchar},
+               (Ptr{Cvoid},), ctx.data)
+    unsafe_string(rv)
+end
+
+
+# C API
+
+function get_peer_cert(ctx::SSLContext)
+    data = ccall((:mbedtls_ssl_get_peer_cert, libmbedtls), Ptr{Cvoid}, (Ptr{Cvoid},), ctx.data)
+    return CRT(data)
+end
+
+function get_version(ctx::SSLContext)
+    if isdefined(ctx, :config)
+        data = ccall((:mbedtls_ssl_get_version, libmbedtls), Ptr{UInt8}, (Ptr{Cvoid},), ctx.data)
+        return unsafe_string(data)
+    else
+        throw(ArgumentError("`ctx` hasn't been initialized with an MbedTLS.SSLConfig; run `MbedTLS.setup!(ctx, conf)`"))
     end
+end
+
+function get_ciphersuite(ctx::SSLContext)
+    data = ccall((:mbedtls_ssl_get_ciphersuite, libmbedtls), Ptr{UInt8}, (Ptr{Cvoid},), ctx.data)
+    return unsafe_string(data)
+end
+
+function set_bio!(ssl_ctx::SSLContext, ctx, f_send::Ptr{Cvoid}, f_recv::Ptr{Cvoid})
+    @lockdata ssl_ctx begin
+        ccall((:mbedtls_ssl_set_bio, libmbedtls), Cvoid,
+            (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+            ssl_ctx.data, ctx, f_send, f_recv, C_NULL)
+    end
+end
+
+function _bytesavailable(ctx::SSLContext)
 
     decrypt_available_bytes(ctx)
 
-    return ctx.isopen && isopen(ctx.bio)
+    @lockdata ctx begin
+
+        # Now that the bufferd bytes have been processed, find out how many
+        # decrypted bytes are available.
+        return Int(ccall((:mbedtls_ssl_get_bytes_avail, libmbedtls),
+                         Csize_t, (Ptr{Cvoid},), ctx.data))
+    end
 end
 
 function decrypt_available_bytes(ctx::SSLContext)
@@ -342,50 +460,10 @@ function decrypt_available_bytes(ctx::SSLContext)
     end
 end
 
-function get_peer_cert(ctx::SSLContext)
-    data = ccall((:mbedtls_ssl_get_peer_cert, libmbedtls), Ptr{Cvoid}, (Ptr{Cvoid},), ctx.data)
-    return CRT(data)
-end
-
-function get_version(ctx::SSLContext)
-    if isdefined(ctx, :config)
-        data = ccall((:mbedtls_ssl_get_version, libmbedtls), Ptr{UInt8}, (Ptr{Cvoid},), ctx.data)
-        return unsafe_string(data)
-    else
-        throw(ArgumentError("`ctx` hasn't been initialized with an MbedTLS.SSLConfig; run `MbedTLS.setup!(ctx, conf)`"))
-    end
-end
-
-function get_ciphersuite(ctx::SSLContext)
-    data = ccall((:mbedtls_ssl_get_ciphersuite, libmbedtls), Ptr{UInt8}, (Ptr{Cvoid},), ctx.data)
-    return unsafe_string(data)
-end
-
-@static if isdefined(Base, :bytesavailable)
-    Base.bytesavailable(ctx::SSLContext) = _bytesavailable(ctx)
-else
-    Base.nb_available(ctx::SSLContext) = _bytesavailable(ctx)
-end
-
-function _bytesavailable(ctx::SSLContext)
-
-    decrypt_available_bytes(ctx)
-
-    @lockdata ctx begin
-
-        # Now that the bufferd bytes have been processed, find out how many
-        # decrypted bytes are available.
-        return Int(ccall((:mbedtls_ssl_get_bytes_avail, libmbedtls),
-                         Csize_t, (Ptr{Cvoid},), ctx.data))
-    end
-end
-
 function hostname!(ctx::SSLContext, hostname)
     @err_check ccall((:mbedtls_ssl_set_hostname, libmbedtls), Cint,
       (Ptr{Cvoid}, Cstring), ctx.data, hostname)
 end
-
-Compat.Sockets.getsockname(ctx::SSLContext) = Compat.Sockets.getsockname(ctx.bio)
 
 const c_send = Ref{Ptr{Cvoid}}(C_NULL)
 const c_recv = Ref{Ptr{Cvoid}}(C_NULL)


### PR DESCRIPTION
This commit makes no semantic changes.

The order that method source code appears in the file has changed but no code within a method has been changed. These changes were made in the process of reviewing and straightening out all of the C function return code handling and state accounting code in `ssl.jl` to resolve #174.

**Changes in this PR**

Added section heading comments to ssl.jl:
 - `# Data Structures`
 - `# Handshake`
 - `# Base ::IO Connection State Methods`
 - `# Sending Data`
 - `# Sending Encrypted Data`
 - `# Receiving Data`
 - `# Receiving Encrypted Data`
 - `# Base ::IO Write Methods`
 - `# Base ::IO Read Methods`
 - `# Configuration`
 - `# C API`

Moved some methods according to section headings.

Added some docstrings.

**Next Steps**

A second PRs will follow to move `ccalls` that need `@lockdata` into wrapper functions under the `# C API` heading.

A third PR will split the implementation of the `Base.unsafe_read` and `Base.unsafe_write` functions into private `ssl_unsafe_read` and `ssl_unsafe_write`.

A final PR will introduce new state management flags and a new scheme for eof detection using the new `mbedtls_ssl_check_pending` API.

**0.6 branch vs master**

The system where #174 originates is based on Julia 0.6, which is why this PR targets that branch.
At this point there are no differences between the `0.6` branch and `master` in `ssl.jl` except for the removal of compat stuff. So, merging these changes to master later should be straightforward.

_Note, the the branch called `0.6` is a release branch for versions greater than `0.5.12`, i.e. it might have been called `release-0.5`. The name refers to the fact that the `0.5.12+` releases support Julia 0.6 whereas `0.6.0+` does not._