### PR TITLE
Resolve #174 - Step 5. Debug logging 🤖

### DIFF
--- a/src/debug.jl
+++ b/src/debug.jl
@@ -1,0 +1,13 @@
+const DEBUG_LEVEL = 0
+
+taskid(t=current_task()) = hex(hash(t) & 0xffff, 4)
+debug_header() = string("MBTLS: ", rpad(Dates.now(), 24), taskid(), " ")
+
+macro debug(n::Int, s)
+    DEBUG_LEVEL >= n ? :(println(debug_header(), $(esc(s)))) :
+                       :()
+end
+
+macro 💀(s) :( @debug 1 $(esc(s)) ) end
+macro 😬(s) :( @debug 2 $(esc(s)) ) end
+macro 🤖(s) :( @debug 3 $(esc(s)) ) end

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -105,6 +105,7 @@ function ssl_abandon(ctx::SSLContext)                                           
     ctx.bytesavailable = 0
     ctx.close_notify_sent = true
     close(ctx.bio)
+    # FIXME probably should ssl_session_reset(ctx)
 end
 
 
@@ -299,8 +300,9 @@ function ssl_unsafe_read(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt)
     try
         while true
 
-            n = ssl_read(ctx, buf + nread, nbytes - nread)                      ;@😬 "ssl_read ⬅️  $n"
-
+            n = ssl_read(ctx, buf + nread, nbytes - nread)                      ;@😬 "ssl_read ⬅️  $n $(n == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY : "(CLOSE_NOTIFY)" ?
+                                                                                                             MBEDTLS_ERR_NET_CONN_RESET        : "(CONN_RESET)" ?
+                                                                                                             MBEDTLS_ERR_SSL_WANT_READ         : "(WANT_READ)")"
             if n == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY ||
                n == MBEDTLS_ERR_NET_CONN_RESET
                 ssl_abandon(ctx)

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -1,3 +1,6 @@
+include("debug.jl")
+
+
 # Data Structures
 
 mutable struct SSLConfig
@@ -56,21 +59,21 @@ end
 function handshake(ctx::SSLContext)
 
     ctx.isreadable && throw(ArgumentError("handshake() already done!"))
-
+                                                                                ;@😬 "🤝 ..."
     while true
         n = ssl_handshake(ctx)
         if n == 0
             break
-        elseif n == MBEDTLS_ERR_SSL_WANT_READ
+        elseif n == MBEDTLS_ERR_SSL_WANT_READ                                   ;@😬 "🤝  ⌛️"
             if eof(ctx.bio)
-                throw(EOFError())
+                throw(EOFError())                                               ;@💀 "🤝  🛑"
             end
         else
-            ssl_abandon(ctx)
+            ssl_abandon(ctx)                                                    ;@💀 "🤝  💥"
             throw(MbedException(n))
         end
     end
-
+                                                                                ;@😬 "🤝  ✅"
     ctx.isreadable = true
     ctx.bytesavailable = 0
     ctx.close_notify_sent = false
@@ -97,7 +100,7 @@ The documentation for `ssl_read`, `ssl_write` and `ssl_close_notify` all say:
 
 This function ensures that the `SSLContext` is won't be used again.
 """
-function ssl_abandon(ctx::SSLContext)
+function ssl_abandon(ctx::SSLContext)                                           ;@💀 "ssl_abandon 💥"
     ctx.isreadable = false
     ctx.bytesavailable = 0
     ctx.close_notify_sent = true
@@ -144,7 +147,7 @@ True if not `isreadable` and there are no more `bytesavailable` to read.
 function Base.eof(ctx::SSLContext)
     if ctx.bytesavailable > 0
         return false
-    end
+    end                                                                         ;@😬 "eof ⌛️"
     wait_for_decrypted_data(ctx)
     @assert ctx.bytesavailable > 0 || !ctx.isreadable
     return ctx.bytesavailable <= 0
@@ -153,14 +156,14 @@ end
 """
 Send a TLS `close_notify` message to the peer.
 """
-function Base.close(ctx::SSLContext)
+function Base.close(ctx::SSLContext)                                            ;@💀 "close iswritable=$(iswritable(ctx))"
 
     if iswritable(ctx)
 
         n = ssl_close_notify(ctx)
-        ctx.close_notify_sent = true
+        ctx.close_notify_sent = true                                            ;@💀 "close 🗣"
 
-        if n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE
+        if n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE    ;@💀 "close ⌛️"
             @assert false "Should not get to here because `f_send` " *
                           "never returns ...WANT_READ/WRITE."
         elseif n != 0
@@ -192,20 +195,20 @@ function ssl_unsafe_write(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt)
     iswritable(ctx) ||
     throw(ArgumentError("`unsafe_write` requires `iswritable(::SSLContext)`"))
 
-    nwritten = 0
+    nwritten = 0                                                                ;@🤖 "ssl_write ➡️  $nbytes"
     while nwritten < nbytes
         n = ssl_write(ctx, buf + nwritten, nbytes - nwritten)
-        if n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE
+        if n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE    ;@💀 "ssl_write ⌛️"
             @assert false "Should not get to here because `f_send` " *
                           "never returns ...WANT_READ/WRITE."
             yield()
             continue
         elseif n == MBEDTLS_ERR_NET_CONN_RESET
-            ssl_abandon(ctx)
+            ssl_abandon(ctx)                                                    ;@🤖 "ssl_write 🛑"
             Base.check_open(ctx.bio)
             @assert false
         elseif n < 0
-            ssl_abandon(ctx)
+            ssl_abandon(ctx)                                                    ;@🤖 "ssl_write 💥"
             throw(MbedException(n))
         end
         nwritten += n
@@ -219,7 +222,7 @@ end
 """
 Copy `nbytes` of encrypted data from `buf` to the underlying `bio` connection.
 """
-function f_send(c_bio, buf, nbytes)
+function f_send(c_bio, buf, nbytes)                                             ;@🤖 "f_send ➡️  $nbytes"
     bio = unsafe_pointer_to_objref(c_bio)
     if !isopen(bio) || bio.status == Base.StatusClosing
         return Cint(MBEDTLS_ERR_NET_CONN_RESET)
@@ -253,10 +256,10 @@ function wait_for_decrypted_data(ctx)
     lock(ctx.waitlock)
     try
         while ctx.isreadable && ctx.bytesavailable <= 0
-            if !ssl_check_pending(ctx)
+            if !ssl_check_pending(ctx)                                          ;@🤖 "wait_for_encrypted_data ⌛️";
                 wait_for_encrypted_data(ctx)
             end
-            ssl_unsafe_read(ctx, Ptr{UInt8}(C_NULL), UInt(0))
+            ssl_unsafe_read(ctx, Ptr{UInt8}(C_NULL), UInt(0))                   ;@🤖 "wait_for_decrypted_data 📥  $(ctx.bytesavailable)"
         end
     finally
         unlock(ctx.waitlock)
@@ -296,7 +299,7 @@ function ssl_unsafe_read(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt)
     try
         while true
 
-            n = ssl_read(ctx, buf + nread, nbytes - nread)
+            n = ssl_read(ctx, buf + nread, nbytes - nread)                      ;@😬 "ssl_read ⬅️  $n"
 
             if n == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY ||
                n == MBEDTLS_ERR_NET_CONN_RESET
@@ -305,7 +308,7 @@ function ssl_unsafe_read(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt)
                 @assert ssl_check_pending(ctx) == false #FIXME remove this
                 return nread
             elseif n == MBEDTLS_ERR_SSL_WANT_READ
-                ctx.bytesavailable = 0
+                ctx.bytesavailable = 0                                          ;@😬 "ssl_read ⌛️ $nread"
                 @assert ssl_get_bytes_avail(ctx) == 0   #FIXME remove this
                 return nread
             elseif n < 0
@@ -317,11 +320,11 @@ function ssl_unsafe_read(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt)
             @assert nread <= nbytes
 
             if nread == nbytes
-                ctx.bytesavailable = ssl_get_bytes_avail(ctx)
+                ctx.bytesavailable = ssl_get_bytes_avail(ctx)                   ;@🤖 "ssl_read ⬅️  $nread, 📥  $(ctx.bytesavailable)"
                 return nread
             end
         end
-    catch e
+    catch e                                                                     ;@💀 "ssl_read 💥"
         ssl_abandon(ctx)
         rethrow(e)
     end
@@ -353,11 +356,11 @@ function f_recv(c_bio, buf, nbytes)
     @assert nbytes > 0
     bio = unsafe_pointer_to_objref(c_bio)
     n = bytesavailable(bio)
-    if n == 0
-        return isopen(bio) ? Cint(MBEDTLS_ERR_SSL_WANT_READ) :
+    if n == 0                                                                   ;@🤖 "f_recv $(isopen(bio) ? "WANT_READ" : "CONN_RESET")"
+        return isopen(bio) ? Cint(MBEDTLS_ERR_SSL_WANT_READ) : 
                              Cint(MBEDTLS_ERR_NET_CONN_RESET)
     end
-    n = min(nbytes, n)
+    n = min(nbytes, n)                                                          ;@🤖 "f_recv ⬅️  $n"
     unsafe_read(bio, buf, n)
     return Cint(n)
 end
@@ -365,7 +368,7 @@ end
 
 # Base ::IO Write Methods -- wrappers for `ssl_unsafe_write`
 
-Base.unsafe_write(ctx::SSLContext, msg::Ptr{UInt8}, N::UInt) =
+Base.unsafe_write(ctx::SSLContext, msg::Ptr{UInt8}, N::UInt) = 
     ssl_unsafe_write(ctx, msg, N)
 
 
@@ -378,16 +381,16 @@ Base.write(ctx::SSLContext, msg::UInt8) = write(ctx, Ref(msg))
 Copy `nbytes` of decrypted data from `ctx` into `buf`.
 Wait for sufficient decrypted data to be available.
 Throw `EOFError` if the peer sends TLS `close_notify` or closes the
-connection before `nbytes` have been copied.
+connection before `nbytes` have been copied. 
 """
 function Base.unsafe_read(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt)
     nread = 0
     while nread < nbytes
-        if eof(ctx)
+        if eof(ctx)                                                             ;@💀 "unsafe_read 🛑"
             throw(EOFError())
         end
         nread += ssl_unsafe_read(ctx, buf + nread, nbytes - nread)
-    end
+    end                                                                         ;@😬 "unsafe_read ⬅️ $nread"
     nothing
 end
 
@@ -410,7 +413,7 @@ function Base.readbytes!(ctx::SSLContext, buf::Vector{UInt8}, nbytes::UInt;
         if !all || eof(ctx)
             break
         end
-    end
+    end                                                                         ;@😬 "readbytes! ⬅️  $nread"
     return nread
 end
 
@@ -424,9 +427,10 @@ The amount of decrypted data that can be read at once is limited by
 function Base.readavailable(ctx::SSLContext)
     n = UInt(MBEDTLS_SSL_MAX_CONTENT_LEN)
     buf = Vector{UInt8}(#=undef,=# n)
-    n = ssl_unsafe_read(ctx, pointer(buf), n)
+    n = ssl_unsafe_read(ctx, pointer(buf), n)                                   ;@😬 "readavailable ⬅️  $n"
     return resize!(buf, n)
 end
+
 
 
 # Configuration


### PR DESCRIPTION
Adds debug logging with timestamp and task hash annotations (matches format produced by `const DEBUG_LEVEL = ` in HTTP.jl).
Using non-text symbols in logs is not to everyone's taste. However, the ability to ask a user to turn on this level of fine-grained logging when they have a hard-to-pin-down timing related issue has been invaluable in supporting HTTP. Also, the different colours and shapes of the symbols really helps to spot odd patterns in a stream of log data.

Below is an example with logging enabled in both HTTP.jl and here:

```
julia> using HTTP ; HTTP.get("https://httpbin.org/ip")
DEBUG: 2018-10-10T21:37:05.219 baa3 🗑  Deleted:        💀    1↑     1↓   19s www.google.com:443:61496 ≣16 RawFD(-1)
DEBUG: 2018-10-10T21:37:05.22  baa3 SSL connect: httpbin.org:443...
DEBUG: 2018-10-10T21:37:05.22  baa3 TCP connect: httpbin.org:443...
MBTLS: 2018-10-10T21:37:05.594 baa3 🤝 ...
MBTLS: 2018-10-10T21:37:05.594 baa3 f_send ➡️  404
MBTLS: 2018-10-10T21:37:05.594 baa3 f_recv WANT_READ
MBTLS: 2018-10-10T21:37:05.594 baa3 🤝  ⌛️
MBTLS: 2018-10-10T21:37:05.901 baa3 f_recv ⬅️  5
MBTLS: 2018-10-10T21:37:05.901 baa3 f_recv ⬅️  87
MBTLS: 2018-10-10T21:37:05.902 baa3 f_recv ⬅️  5
MBTLS: 2018-10-10T21:37:05.902 baa3 f_recv ⬅️  2744
MBTLS: 2018-10-10T21:37:05.903 baa3 f_recv ⬅️  5
MBTLS: 2018-10-10T21:37:05.903 baa3 f_recv ⬅️  401
MBTLS: 2018-10-10T21:37:05.903 baa3 f_recv ⬅️  5
MBTLS: 2018-10-10T21:37:05.904 baa3 f_recv ⬅️  4
MBTLS: 2018-10-10T21:37:05.921 baa3 f_send ➡️  143
MBTLS: 2018-10-10T21:37:05.922 baa3 f_send ➡️  6
MBTLS: 2018-10-10T21:37:05.922 baa3 f_send ➡️  45
MBTLS: 2018-10-10T21:37:05.922 baa3 f_recv WANT_READ
MBTLS: 2018-10-10T21:37:05.922 baa3 🤝  ⌛️
MBTLS: 2018-10-10T21:37:06.617 baa3 f_recv ⬅️  5
MBTLS: 2018-10-10T21:37:06.617 baa3 f_recv ⬅️  1
MBTLS: 2018-10-10T21:37:06.617 baa3 f_recv ⬅️  5
MBTLS: 2018-10-10T21:37:06.618 baa3 f_recv ⬅️  40
MBTLS: 2018-10-10T21:37:06.618 baa3 🤝  ✅
DEBUG: 2018-10-10T21:37:06.618 baa3 🔗  New:            ⏸    0↑     0↓    0s httpbin.org:443:61497 ≣16 RawFD(24)
DEBUG: 2018-10-10T21:37:06.618 baa3 👁  Start write:T0  ⏸    0↑     0↓    0s httpbin.org:443:61497 ≣16 RawFD(24)
DEBUG: 2018-10-10T21:37:06.618 baa3 ➡️  "GET /ip HTTP/1.1\r\n"
MBTLS: 2018-10-10T21:37:06.618 baa3 ssl_write ➡️  18
MBTLS: 2018-10-10T21:37:06.618 baa3 f_send ➡️  47
MBTLS: 2018-10-10T21:37:06.618 3422 wait_for_encrypted_data ⌛️
DEBUG: 2018-10-10T21:37:06.618 baa3 ➡️  "Host: httpbin.org\r\n"
MBTLS: 2018-10-10T21:37:06.618 baa3 ssl_write ➡️  19
MBTLS: 2018-10-10T21:37:06.618 baa3 f_send ➡️  48
DEBUG: 2018-10-10T21:37:06.619 baa3 ➡️  "Content-Length: 0\r\n"
MBTLS: 2018-10-10T21:37:06.619 baa3 ssl_write ➡️  19
MBTLS: 2018-10-10T21:37:06.619 baa3 f_send ➡️  48
DEBUG: 2018-10-10T21:37:06.619 baa3 ➡️  "\r\n"
MBTLS: 2018-10-10T21:37:06.619 baa3 ssl_write ➡️  2
MBTLS: 2018-10-10T21:37:06.619 baa3 f_send ➡️  31
DEBUG: 2018-10-10T21:37:06.622 1c93 🗣  Write done: T0  🔁    1↑     0↓    0s httpbin.org:443:61497 ≣16 RawFD(24)
DEBUG: 2018-10-10T21:37:06.622 baa3 👁  Start read: T0  🔁    1↑     0↓    0s httpbin.org:443:61497 ≣16 RawFD(24)
MBTLS: 2018-10-10T21:37:06.622 baa3 eof ⌛️
MBTLS: 2018-10-10T21:37:07.232 3422 f_recv ⬅️  5
MBTLS: 2018-10-10T21:37:07.232 3422 f_recv ⬅️  300
MBTLS: 2018-10-10T21:37:07.232 3422 ssl_read ⬅️  0
MBTLS: 2018-10-10T21:37:07.232 3422 ssl_read ⬅️  0, 📥  276
MBTLS: 2018-10-10T21:37:07.232 3422 wait_for_decrypted_data 📥  276
MBTLS: 2018-10-10T21:37:07.233 baa3 ssl_read ⬅️  276
MBTLS: 2018-10-10T21:37:07.233 baa3 f_recv WANT_READ
MBTLS: 2018-10-10T21:37:07.233 baa3 ssl_read ⬅️  -26880
MBTLS: 2018-10-10T21:37:07.233 baa3 ssl_read ⌛️ 276
MBTLS: 2018-10-10T21:37:07.233 baa3 readavailable ⬅️  276
DEBUG: 2018-10-10T21:37:07.233 baa3 ⬅️  "HTTP/1.1 200 OK\r\n"
DEBUG:                                 "Connection: keep-alive\r\n"
DEBUG:                                 "Server: gunicorn/19.9.0\r\n"
DEBUG:                                 "Date: Wed, 10 Oct 2018 10:37:07 GMT\r\n"
DEBUG:                                 "Content-Type: application/json\r\n"
DEBUG:                                 "Content-Length: 31\r\n"
DEBUG:                                 "Access-Control-Allow-Origin: *\r\n"
DEBUG:                                 "Access-Control-Allow-Credentials: true\r\n"
DEBUG:                                 "Via: 1.1 vegur\r\n"
DEBUG:                                 "\r\n"
DEBUG:                                 "{\n"
DEBUG:                                 "  \"origin\": \"60.224.142.5\"\n"
DEBUG:                                 "}\n"
DEBUG: 2018-10-10T21:37:07.235 baa3 ♻️  "{\n"
DEBUG:                                 "  \"origin\": \"60.224.142.5\"\n"
DEBUG:                                 "}\n"
DEBUG: 2018-10-10T21:37:07.235 baa3 ⬅️  "{\n"
DEBUG:                                 "  \"origin\": \"60.224.142.5\"\n"
DEBUG:                                 "}\n"
DEBUG: 2018-10-10T21:37:07.237 baa3 ✉️  Read done:  T0  ⏸    1↑     1↓    0s httpbin.org:443:61497 ≣16 RawFD(24)
HTTP.Messages.Response:
"""
HTTP/1.1 200 OK
Connection: keep-alive
Server: gunicorn/19.9.0
Date: Wed, 10 Oct 2018 10:37:07 GMT
Content-Type: application/json
Content-Length: 31
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
Via: 1.1 vegur

{
  "origin": "60.224.142.5"
}
"""
```
