### PR TITLE
add NSS Key Log Format export for debugging with Wireshark

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,23 @@ write(ctx, "GET / HTTP/1.1\r\nHost: httpbin.org\r\n\r\n")
 buf = String(read(ctx, 100))
 @test ismatch(r"^HTTP/1.1 200 OK", buf)
 ```
+
+Debugging with Wireshark.
+
+MbedTLS.jl can optionally log TLS session keys in
+[NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format).
+
+e.g.
+```julia
+using HTTP
+using MbedTLS
+c = MbedTLS.SSLConfig(true, log_secrets="/Users/sam/stuff/secret_key_log")
+HTTP.get("https://httpbin.org/ip", sslconfig=c)
+```
+
+Wireshark can be configrued to decrypt SSL traffic by setting the location
+of the key log file under:
+
+    Wireshark Preferences -> Protocols -> SSL; (Pre-)Master Secret log filename.
+
+See: https://sharkfesteurope.wireshark.org/assets/presentations17eu/15.pdf

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -120,7 +120,8 @@ function ssl_abandon(ctx::SSLContext)                                           
     ctx.bytesavailable = 0
     ctx.close_notify_sent = true
     close(ctx.bio)
-    # FIXME probably should ssl_session_reset(ctx)
+    n = ssl_session_reset(ctx)
+    n == 0 || throw(MbedException(n))
 end
 
 
@@ -717,6 +718,17 @@ https://tls.mbed.org/api/ssl_8h.html#ac2c1b17128ead2df3082e27b603deb4c
 function ssl_close_notify(ctx::SSLContext)
     @lockdata ctx begin
         return ccall((:mbedtls_ssl_close_notify, libmbedtls),
+                     Cint, (Ptr{Cvoid},), ctx.data)
+    end
+end
+
+"""
+Reset an already initialized SSL context for re-use while retaining
+application-set variables, function pointers and data.
+"""
+function ssl_session_reset(ctx::SSLContext)
+    @lockdata ctx begin
+        return ccall((:mbedtls_ssl_session_reset, libmbedtls),
                      Cint, (Ptr{Cvoid},), ctx.data)
     end
 end

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -16,9 +16,13 @@ mutable struct SSLConfig
         conf = new()
         conf.data = Libc.malloc(1000)  # 360
         ccall((:mbedtls_ssl_config_init, libmbedtls), Cvoid, (Ptr{Cvoid},), conf.data)
-        finalizer(conf->begin
-            ccall((:mbedtls_ssl_config_free, libmbedtls), Cvoid, (Ptr{Cvoid},), conf.data)
-            Libc.free(conf.data)
+        finalizer(x->begin
+            data = x.data
+            @async begin
+                ccall((:mbedtls_ssl_config_free, libmbedtls),
+                      Cvoid, (Ptr{Cvoid},), data)
+                Libc.free(data)
+            end
         end, conf)
         conf
     end
@@ -47,9 +51,13 @@ mutable struct SSLContext <: IO
         ctx.close_notify_sent = false
         ctx.async_exception = nothing
         ccall((:mbedtls_ssl_init, libmbedtls), Cvoid, (Ptr{Cvoid},), ctx.data)
-        finalizer(ctx->begin
-            ccall((:mbedtls_ssl_free, libmbedtls), Cvoid, (Ptr{Cvoid},), ctx.data)
-            Libc.free(ctx.data)
+        finalizer(x->begin
+            data = x.data
+            @async begin
+                ccall((:mbedtls_ssl_free, libmbedtls),
+                      Cvoid, (Ptr{Cvoid},), ctx.data)
+                Libc.free(ctx.data)
+            end
         end, ctx)
         ctx
     end


### PR DESCRIPTION
These changes allow optional logging of TLS session keys in [NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format).

e.g.
```julia
using HTTP
using MbedTLS
c = MbedTLS.SSLConfig(true, log_secrets="/Users/sam/stuff/secret_key_log")
HTTP.get("https://httpbin.org/ip", sslconfig=c)
```
```bash
$ cat ~/stuff/ssl_secrets
CLIENT_RANDOM 5bce76ef6459645d91f6eceabc44bacbafe9a919ed6d7d8c701677b2105d7387 b6ed4d5ff6e4c69454ce62371d0e799cea442a4ea5c7e4fdf4ac5e5416d68ff4869cd3b839db808ecc836c3748e6cbd9
```

Wireshark can be configrued to decrypt SSL traffic by setting the location of the key log file under:

    Wireshark Preferences -> Protocols -> SSL; (Pre-)Master Secret log filename.

See: https://sharkfesteurope.wireshark.org/assets/presentations17eu/15.pdf

## Also...
 - Call `mbedtls_ssl_session_reset` in `ssl_abandon` per FIXME
 - Defer mbedtls_*free calls in finalisers to @async task to avoid debug IO related task switching. See https://github.com/JuliaLang/julia/pull/25141 and https://github.com/JuliaWeb/MbedTLS.jl/pull/181#issuecomment-433196141