### PR TITLE
Fix dlopen order, call check_deps() in __init__

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,16 +5,16 @@ const verbose = "--verbose" in ARGS
 const prefix = Prefix(get([a for a in ARGS if a != "--verbose"], 1, joinpath(@__DIR__, "usr")))
 products = [
     LibraryProduct(prefix, String["libmbedcrypto"], :libmbedcrypto),
-    LibraryProduct(prefix, String["libmbedtls"], :libmbedtls),
     LibraryProduct(prefix, String["libmbedx509"], :libmbedx509),
+    LibraryProduct(prefix, String["libmbedtls"], :libmbedtls),
 ]
 
 const juliaprefix = joinpath(Sys.BINDIR, "..")
 
 juliaproducts = Product[
-    LibraryProduct(juliaprefix, "libmbedtls", :libmbedtls)
     LibraryProduct(juliaprefix, "libmbedcrypto", :libmbedcrypto)
     LibraryProduct(juliaprefix, "libmbedx509", :libmbedx509)
+    LibraryProduct(juliaprefix, "libmbedtls", :libmbedtls)
 ]
 
 # Download binaries from hosted location

--- a/src/MbedTLS.jl
+++ b/src/MbedTLS.jl
@@ -58,6 +58,7 @@ include("x509_crt.jl")
 include("ssl.jl")
 
 function __init__()
+    check_deps()
     __ctr_drbg__init__()
     __sslinit__()
     __entropyinit__()


### PR DESCRIPTION
Found while investigating https://github.com/JuliaWeb/MbedTLS.jl/issues/193. This still doesn't fix HTTP.jl tests, but I think these are good changes nonetheless.