### PR TITLE
pk/rsa: Fix GC rooting issues and fill out API

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,6 +197,15 @@ let
     @test MbedTLS.bitlength(key) == 2048
     @test MbedTLS.get_name(key) == "RSA"
 
+    let rsa = MbedTLS.RSA(key)
+        MbedTLS.complete!(rsa)
+        buf = IOBuffer()
+        MbedTLS.mpi_export!(buf, rsa.E)
+        MbedTLS.mpi_export!(buf, rsa.N)
+        arr = take!(buf)
+        @test sizeof(arr) == 259
+    end
+
     pubkey = MbedTLS.parse_public_keyfile(joinpath(@__DIR__, "public_key.pem"))
     @test MbedTLS.bitlength(pubkey) == 2048
     @test MbedTLS.get_name(pubkey) == "RSA"


### PR DESCRIPTION
MbedTLS is passing raw pointers to C without rooting ownership all over the place. This fixes these issues in the pk/rsa code and fills out the API a bit for round-trip testing, as well as adding GC-safe wrappers over the internal mp integers for downstream code to use. Of course, the unsafe GC pattern is repeated elsewhere in this package, so this is just a first PR that fixed the API surface that I happened to need.