### PR TITLE
Add `parse_key` and `parse_public_key` methods

### DIFF
--- a/src/pk.jl
+++ b/src/pk.jl
@@ -48,6 +48,12 @@ function parse_public_key!(ctx::PKContext, key)
         ctx.data, key_bs, sizeof(key_bs) + 1)
 end
 
+function parse_public_key(key)
+    ctx = PKContext()
+    parse_public_key!(ctx, key)
+    ctx
+end
+
 function parse_key!(ctx::PKContext, key, maybe_pw = nothing)
     key_bs = String(key)
     if maybe_pw === nothing
@@ -60,6 +66,12 @@ function parse_key!(ctx::PKContext, key, maybe_pw = nothing)
     @err_check ccall((:mbedtls_pk_parse_key, libmbedcrypto), Cint,
         (Ptr{Cvoid}, Ptr{Cuchar}, Csize_t, Ptr{Cuchar}, Csize_t),
         ctx.data, key_bs, sizeof(key_bs) + 1, pw, pw_size)
+end
+
+function parse_key(key, maybe_pw = nothing)
+    ctx = PKContext()
+    parse_key!(ctx, key, maybe_pw)
+    ctx
 end
 
 function bitlength(ctx::PKContext)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,9 +187,17 @@ let
     @test MbedTLS.bitlength(key) == 2048
     @test MbedTLS.get_name(key) == "RSA"
 
+    key = MbedTLS.parse_key(key_string)
+    @test MbedTLS.bitlength(key) == 2048
+    @test MbedTLS.get_name(key) == "RSA"
+
     pubkey_string = read(open(joinpath(@__DIR__, "public_key.pem"), "r"))
     pubkey = MbedTLS.PKContext()
     MbedTLS.parse_public_key!(pubkey, pubkey_string)
+    @test MbedTLS.bitlength(pubkey) == 2048
+    @test MbedTLS.get_name(pubkey) == "RSA"
+
+    pubkey = MbedTLS.parse_public_key(pubkey_string)
     @test MbedTLS.bitlength(pubkey) == 2048
     @test MbedTLS.get_name(pubkey) == "RSA"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,6 +187,7 @@ let
     @test MbedTLS.bitlength(key) == 2048
     @test MbedTLS.get_name(key) == "RSA"
 
+    key_string = read(open(joinpath(@__DIR__, "key.pem"), "r"))
     key = MbedTLS.parse_key(key_string)
     @test MbedTLS.bitlength(key) == 2048
     @test MbedTLS.get_name(key) == "RSA"
@@ -197,6 +198,7 @@ let
     @test MbedTLS.bitlength(pubkey) == 2048
     @test MbedTLS.get_name(pubkey) == "RSA"
 
+    pubkey_string = read(open(joinpath(@__DIR__, "public_key.pem"), "r"))
     pubkey = MbedTLS.parse_public_key(pubkey_string)
     @test MbedTLS.bitlength(pubkey) == 2048
     @test MbedTLS.get_name(pubkey) == "RSA"


### PR DESCRIPTION
This PR adds `MbedTLS.parse_key` and `MbedTLS.parse_public_key` methods which are arguably convenient additions and complement `MbedTLS.parse_key!` and `MbedTLS.parse_public_key!` in the same way as `MbedTLS.parse_keyfile`/`MbedTLS.parse_keyfile!` and `MbedTLS.parse_public_keyfile`/`MbedTLS.parse_public_keyfile!`.